### PR TITLE
Minor refactor of ConfigSelect

### DIFF
--- a/src/sql/ConfigEditor/ConfigSelect.test.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.test.tsx
@@ -6,50 +6,23 @@ import { select } from 'react-select-event';
 
 const props: ConfigSelectProps = {
   ...mockDatasourceOptions,
-  jsonDataPath: 'foo',
+  value: 'foo',
+  onChange: jest.fn(),
   fetch: jest.fn(),
   saveOptions: jest.fn(),
 };
 
 describe('SQLTextInput', () => {
-  it('should update jsonData', async () => {
+  it('should call onChange with the new value', async () => {
     const fetch = jest.fn().mockResolvedValue(['bar']);
-    const onOptionsChange = jest.fn();
+    const onChange = jest.fn();
     const label = 'foo-id';
-    render(<ConfigSelect {...props} label={label} fetch={fetch} onOptionsChange={onOptionsChange} />);
+    render(<ConfigSelect {...props} label={label} fetch={fetch} onChange={onChange} />);
 
     const selectEl = screen.getByLabelText(label);
     expect(selectEl).toBeInTheDocument();
     await select(selectEl, 'bar', { container: document.body });
     expect(fetch).toHaveBeenCalled();
-    expect(onOptionsChange).toHaveBeenCalledWith({
-      ...props.options,
-      jsonData: {
-        ...props.options.jsonData,
-        foo: 'bar',
-      },
-    });
-  });
-
-  it('should call deep nested jsonData value', async () => {
-    const onOptionsChange = jest.fn();
-    const fetch = jest.fn().mockResolvedValue(['foobar']);
-    const label = 'foo-id';
-    render(
-      <ConfigSelect {...props} label={label} jsonDataPath="foo.bar" fetch={fetch} onOptionsChange={onOptionsChange} />
-    );
-    const selectEl = screen.getByLabelText(label);
-    expect(selectEl).toBeInTheDocument();
-    await select(selectEl, 'foobar', { container: document.body });
-    expect(fetch).toHaveBeenCalled();
-    expect(onOptionsChange).toHaveBeenCalledWith({
-      ...props.options,
-      jsonData: {
-        ...props.options.jsonData,
-        foo: {
-          bar: 'foobar',
-        },
-      },
-    });
+    expect(onChange).toHaveBeenCalledWith({ label: 'bar', value: 'bar' });
   });
 });

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -13,7 +13,6 @@ export interface ConfigSelectProps
   'data-testid'?: string;
   hidden?: boolean;
   disabled?: boolean;
-  jsonDataPathLabel?: string;
   saveOptions: () => Promise<void>;
 }
 

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '../../types';
 import { ResourceSelector } from '../ResourceSelector';
-import { set, get } from 'lodash';
 
 export interface ConfigSelectProps
   extends DataSourcePluginOptionsEditorProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> {
-  jsonDataPath: string;
+  value: string;
   fetch: () => Promise<Array<string | SelectableValue<string>>>;
+  onChange: (e: SelectableValue<string> | null) => void;
   dependencies?: string[];
   label?: string;
   'data-testid'?: string;
@@ -25,16 +25,6 @@ export function ConfigSelect(props: ConfigSelectProps) {
     labelWidth: 28,
     className: 'width-30',
   };
-  const onChange = (e: SelectableValue<string> | null) => {
-    const newOptions = {
-      ...props.options,
-    };
-    set(newOptions.jsonData, props.jsonDataPath, e ? e.value || '' : e);
-    if (props.jsonDataPathLabel) {
-      set(newOptions.jsonData, props.jsonDataPathLabel, e ? e.label || '' : e);
-    }
-    props.onOptionsChange(newOptions);
-  };
   // Any change in the AWS connection details will affect selectors
   const dependencies: string[] = [
     props.options.jsonData.assumeRoleArn,
@@ -48,9 +38,9 @@ export function ConfigSelect(props: ConfigSelectProps) {
     <ResourceSelector
       label={props.label}
       data-testid={props['data-testid']}
-      onChange={onChange}
+      onChange={props.onChange}
       fetch={props.fetch}
-      value={get(props.options.jsonData, props.jsonDataPath)}
+      value={props.value}
       saveOptions={props.saveOptions}
       dependencies={dependencies}
       hidden={props.hidden}

--- a/src/sql/ConfigEditor/InlineInput.test.tsx
+++ b/src/sql/ConfigEditor/InlineInput.test.tsx
@@ -5,42 +5,21 @@ import { mockDatasourceOptions } from './__mocks__/datasource';
 
 const props: InlineInputProps = {
   ...mockDatasourceOptions,
-  jsonDataPath: 'foo',
+  value: 'foo',
+  onChange: jest.fn(),
 };
 
 describe('InlineInput', () => {
-  it('should show jsonData value', () => {
-    render(<InlineInput {...props} options={{ ...props.options, jsonData: { foo: 'bar' } }} />);
+  it('should show value', () => {
+    render(<InlineInput {...props} value={'bar'} />);
     expect(screen.queryByDisplayValue('bar')).toBeInTheDocument();
   });
 
-  it('should update jsonData', () => {
+  it('should call onChange with the new value', async () => {
     const testID = 'foo-id';
-    const onOptionsChange = jest.fn();
-    render(<InlineInput {...props} data-testid={testID} onOptionsChange={onOptionsChange} />);
+    const onChange = jest.fn();
+    render(<InlineInput {...props} data-testid={testID} onChange={onChange} />);
     fireEvent.change(screen.getByTestId(testID), { target: { value: 'bar' } });
-    expect(onOptionsChange).toHaveBeenCalledWith({
-      ...props.options,
-      jsonData: {
-        ...props.options.jsonData,
-        foo: 'bar',
-      },
-    });
-  });
-
-  it('should update deep nested jsonData value', () => {
-    const onOptionsChange = jest.fn();
-    const testID = 'foo-id';
-    render(<InlineInput {...props} data-testid={testID} onOptionsChange={onOptionsChange} jsonDataPath="foo.bar" />);
-    fireEvent.change(screen.getByTestId(testID), { target: { value: 'foobar' } });
-    expect(onOptionsChange).toHaveBeenCalledWith({
-      ...props.options,
-      jsonData: {
-        ...props.options.jsonData,
-        foo: {
-          bar: 'foobar',
-        },
-      },
-    });
+    expect(onChange).toHaveBeenCalled();
   });
 });

--- a/src/sql/ConfigEditor/InlineInput.tsx
+++ b/src/sql/ConfigEditor/InlineInput.tsx
@@ -3,10 +3,10 @@ import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { AwsAuthDataSourceSecureJsonData } from '../../types';
 import { InlineField, Input } from '@grafana/ui';
 import { FormEvent } from 'react-dom/node_modules/@types/react';
-import { get, set } from 'lodash';
 
 export interface InlineInputProps extends DataSourcePluginOptionsEditorProps<{}, AwsAuthDataSourceSecureJsonData> {
-  jsonDataPath: string;
+  value: string;
+  onChange: (e: FormEvent<HTMLInputElement>) => void;
   label?: string;
   tooltip?: string;
   placeholder?: string;
@@ -16,14 +16,6 @@ export interface InlineInputProps extends DataSourcePluginOptionsEditorProps<{},
 }
 
 export function InlineInput(props: InlineInputProps) {
-  const onChange = (e: FormEvent<HTMLInputElement>) => {
-    const newOptions = {
-      ...props.options,
-    };
-    set(newOptions.jsonData, props.jsonDataPath, e.currentTarget.value || '');
-    props.onOptionsChange(newOptions);
-  };
-
   return (
     <InlineField
       label={props.label}
@@ -35,8 +27,8 @@ export function InlineInput(props: InlineInputProps) {
       <Input
         data-testid={props['data-testid']}
         className="width-30"
-        value={get(props.options.jsonData, props.jsonDataPath, '')}
-        onChange={onChange}
+        value={props.value}
+        onChange={props.onChange}
         placeholder={props.placeholder}
         disabled={props.disabled}
       />


### PR DESCRIPTION
follow up of #4

Re-reading this I was not very happy with the `jsonDataPath` parameter that I added to the `ConfigSelect` component. I did it to avoid having to define the `onChange` function for each data source config but we are losing the strict typing (you could use a `jsonDataPath` that didn't exist). So I am removing it here.

[EDIT]

I also modified the `InlineInput` component with the same logic