### PR TITLE
SQL Query code editor: remove unused parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.0.32-pre.1",
+  "version": "0.0.32-pre.2",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "scripts": {

--- a/src/sql/QueryEditor/QueryCodeEditor.tsx
+++ b/src/sql/QueryEditor/QueryCodeEditor.tsx
@@ -20,12 +20,11 @@ type Props<TQuery extends DataQuery> = {
   editorProps?: EditorProps;
   onChange: (value: TQuery) => void;
   onRunQuery: () => void;
-  getSuggestions: (templateSrv: any, query: TQuery) => CodeEditorSuggestionItem[];
-  getTemplateSrv: () => any;
+  getSuggestions: (query: TQuery) => CodeEditorSuggestionItem[];
 };
 
 export function QueryCodeEditor<TQuery extends DataQuery>(props: Props<TQuery>) {
-  const { getSuggestions, getTemplateSrv, query } = props;
+  const { getSuggestions, query } = props;
   const { rawSQL } = defaults(props.query, { rawSQL: '' });
   const onRawSqlChange = (rawSQL: string) => {
     const query = {
@@ -42,8 +41,8 @@ export function QueryCodeEditor<TQuery extends DataQuery>(props: Props<TQuery>) 
   // versions.
   const suggestionsRef = useRef<CodeEditorSuggestionItem[]>([]);
   useEffect(() => {
-    suggestionsRef.current = getSuggestions(getTemplateSrv(), query);
-  }, [getSuggestions, getTemplateSrv, query]);
+    suggestionsRef.current = getSuggestions(query);
+  }, [getSuggestions, query]);
 
   return (
     <CodeEditor


### PR DESCRIPTION
No need to pass over the `getTemplateSrv` function since it's only used in the `getSuggestions` function, which is defined in the plugin, which has access to the TemplateSrv getter.