### PR TITLE
ConfigSelect : Fixed disabled prop overriden and added prop to allow custom input

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean": "rimraf ./dist ./compiled",
     "typecheck": "tsc --noEmit",
     "test": "jest --notify --watch",
+    "test:coverage": "jest --coverage",
     "test-ci": "grafana-toolkit plugin:test"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "scripts": {

--- a/src/sql/ConfigEditor/ConfigSelect.test.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.test.tsx
@@ -21,8 +21,27 @@ describe('SQLTextInput', () => {
 
     const selectEl = screen.getByLabelText(label);
     expect(selectEl).toBeInTheDocument();
+    expect(selectEl).not.toBeDisabled();
     await select(selectEl, 'bar', { container: document.body });
     expect(fetch).toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith({ label: 'bar', value: 'bar' });
+  });
+
+  it('should show disabled select if passed disabled as prop', () => {
+    const label = 'foo-id';
+    render(<ConfigSelect {...props} disabled={true} label={label} />);
+    const selectEl = screen.getByLabelText(label);
+
+    expect(selectEl).toBeDisabled();
+  });
+
+  it('should show disabled select if passed disabled=false as prop but jsonData.defaultRegion is not set', () => {
+    const propsWithoutDefaultRegion = { ...props };
+    propsWithoutDefaultRegion.options.jsonData = {};
+    const label = 'foo-id';
+    render(<ConfigSelect {...propsWithoutDefaultRegion} disabled={false} label={label} />);
+    const selectEl = screen.getByLabelText(label);
+
+    expect(selectEl).toBeDisabled();
   });
 });

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -13,6 +13,7 @@ export interface ConfigSelectProps
   'data-testid'?: string;
   hidden?: boolean;
   disabled?: boolean;
+  allowCustomValue?: boolean;
   saveOptions: () => Promise<void>;
 }
 
@@ -43,6 +44,7 @@ export function ConfigSelect(props: ConfigSelectProps) {
       dependencies={dependencies}
       hidden={props.hidden}
       disabled={props.disabled || !jsonData.defaultRegion}
+      allowCustomValue={props.allowCustomValue}
       {...commonProps}
     />
   );

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -20,7 +20,6 @@ export function ConfigSelect(props: ConfigSelectProps) {
   const { jsonData } = props.options;
   const commonProps = {
     title: jsonData.defaultRegion ? '' : 'select a default region',
-    disabled: !jsonData.defaultRegion,
     labelWidth: 28,
     className: 'width-30',
   };
@@ -43,7 +42,7 @@ export function ConfigSelect(props: ConfigSelectProps) {
       saveOptions={props.saveOptions}
       dependencies={dependencies}
       hidden={props.hidden}
-      disabled={props.disabled}
+      disabled={props.disabled && !jsonData.defaultRegion}
       {...commonProps}
     />
   );

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -42,7 +42,7 @@ export function ConfigSelect(props: ConfigSelectProps) {
       saveOptions={props.saveOptions}
       dependencies={dependencies}
       hidden={props.hidden}
-      disabled={props.disabled && !jsonData.defaultRegion}
+      disabled={props.disabled || !jsonData.defaultRegion}
       {...commonProps}
     />
   );

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -66,6 +66,26 @@ export function ConfigSelect(props: ConfigSelectProps) {
       hidden={props.hidden}
       disabled={props.disabled || !jsonData.defaultRegion}
       allowCustomValue={props.allowCustomValue}
+      autoFocus={props.autoFocus}
+      backspaceRemovesValue={props.backspaceRemovesValue}
+      className={props.className}
+      invalid={props.invalid}
+      isClearable={props.isClearable}
+      isMulti={props.isMulti}
+      inputId={props.inputId}
+      showAllSelectedWhenOpen={props.showAllSelectedWhenOpen}
+      maxMenuHeight={props.maxMenuHeight}
+      minMenuHeight={props.minMenuHeight}
+      maxVisibleValues={props.maxVisibleValues}
+      menuPlacement={props.menuPlacement}
+      menuPosition={props.menuPosition}
+      noOptionsMessage={props.noOptionsMessage}
+      onBlur={props.onBlur}
+      onCreateOption={props.onCreateOption}
+      onInputChange={props.onInputChange}
+      placeholder={props.placeholder}
+      width={props.width}
+      isOptionDisabled={props.isOptionDisabled}
       {...commonProps}
     />
   );

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
+import { InputActionMeta } from '@grafana/ui/components/Select/types';
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '../../types';
 import { ResourceSelector } from '../ResourceSelector';
 
@@ -15,6 +16,26 @@ export interface ConfigSelectProps
   disabled?: boolean;
   allowCustomValue?: boolean;
   saveOptions: () => Promise<void>;
+  autoFocus?: boolean;
+  backspaceRemovesValue?: boolean;
+  className?: string;
+  invalid?: boolean;
+  isClearable?: boolean;
+  isMulti?: boolean;
+  inputId?: string;
+  showAllSelectedWhenOpen?: boolean;
+  maxMenuHeight?: number;
+  minMenuHeight?: number;
+  maxVisibleValues?: number;
+  menuPlacement?: 'auto' | 'bottom' | 'top';
+  menuPosition?: 'fixed' | 'absolute';
+  noOptionsMessage?: string;
+  onBlur?: () => void;
+  onCreateOption?: (value: string) => void;
+  onInputChange?: (value: string, actionMeta: InputActionMeta) => void;
+  placeholder?: string;
+  width?: number;
+  isOptionDisabled?: () => boolean;
 }
 
 export function ConfigSelect(props: ConfigSelectProps) {

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -18,6 +18,7 @@ export type ResourceSelectorProps = {
   // Options only needed for the ConfigEditor
   title?: string;
   disabled?: boolean;
+  allowCustomValue?: boolean;
   labelWidth?: number;
   className?: string;
   saveOptions?: () => Promise<void>;
@@ -118,6 +119,8 @@ export function ResourceSelector(props: ResourceSelectorProps) {
           className={props.className || 'min-width-6'}
           disabled={props.disabled}
           onOpenMenu={() => props.fetch && onClick()}
+          allowCustomValue={props.allowCustomValue}
+          menuShouldPortal={true}
         />
       </div>
     </InlineField>

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -108,15 +108,13 @@ export function ResourceSelector(props: ResourceSelectorProps) {
     <InlineField label={props.label} labelWidth={props.labelWidth} tooltip={props.tooltip} hidden={props.hidden}>
       <div data-testid={props['data-testid']} title={props.title}>
         <Select
+          {...props}
           aria-label={props.label}
           options={options}
-          value={props.value}
           onChange={onChange}
           isLoading={isLoading}
           className={props.className || 'min-width-6'}
-          disabled={props.disabled}
           onOpenMenu={() => props.fetch && onClick()}
-          allowCustomValue={props.allowCustomValue}
           menuShouldPortal={true}
         />
       </div>

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -1,13 +1,13 @@
 import { SelectableValue } from '@grafana/data';
 import { InlineField, Select } from '@grafana/ui';
+import { SelectCommonProps } from '@grafana/ui/components/Select/types';
 import { isEqual } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { defaultKey } from './types';
 
-export type ResourceSelectorProps = {
+export interface ResourceSelectorProps extends SelectCommonProps<string> {
   value: string | null;
-  onChange: (e: SelectableValue<string> | null) => void;
   dependencies?: Array<string | null | undefined>;
   tooltip?: string;
   label?: string;
@@ -17,15 +17,12 @@ export type ResourceSelectorProps = {
   default?: string;
   // Options only needed for the ConfigEditor
   title?: string;
-  disabled?: boolean;
-  allowCustomValue?: boolean;
   labelWidth?: number;
-  className?: string;
   saveOptions?: () => Promise<void>;
   // Either set a way of fetching resources or the resource list
   fetch?: () => Promise<Array<string | SelectableValue<string>>>;
   resources?: string[];
-};
+}
 
 export function ResourceSelector(props: ResourceSelectorProps) {
   const [resource, setResource] = useState<string | null>(props.value || props.default || null);

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -120,7 +120,6 @@ export function ResourceSelector(props: ResourceSelectorProps) {
           disabled={props.disabled}
           onOpenMenu={() => props.fetch && onClick()}
           allowCustomValue={props.allowCustomValue}
-          menuShouldPortal={true}
         />
       </div>
     </InlineField>


### PR DESCRIPTION
This PR is needed for https://github.com/grafana/redshift-datasource/pull/130 

Two changes:
1. Added an optional `allowCustomValue` prop to ConfigSelect
2. Fixed an issue with the `disabled` prop that was over written by `jsonData.defaultRegion`