### PR TITLE
Clean up: Fixed unit test warnings

### DIFF
--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -80,6 +80,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
           onChange={(option) => {
             onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
           }}
+          menuShouldPortal={true}
         />
       </InlineField>
       {options.jsonData.authType === 'credentials' && (
@@ -199,6 +200,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
           allowCustomValue={true}
           onChange={onUpdateDatasourceJsonDataOptionSelect(props, 'defaultRegion')}
           formatCreateLabel={(r) => `Use region: ${r}`}
+          menuShouldPortal={true}
         />
       </InlineField>
       {props.children}

--- a/src/sql/QueryEditor/FillValueSelect.tsx
+++ b/src/sql/QueryEditor/FillValueSelect.tsx
@@ -46,6 +46,7 @@ export function FillValueSelect<TQuery extends DataQuery & Record<string, any>>(
             props.onRunQuery();
           }}
           className="width-12"
+          menuShouldPortal={true}
         />
       </InlineField>
       {props.query.fillMode?.mode === FillValueOptions.Value && (

--- a/src/sql/QueryEditor/FormatSelect.tsx
+++ b/src/sql/QueryEditor/FormatSelect.tsx
@@ -27,6 +27,7 @@ export function FormatSelect<TQuery extends DataQuery & Record<string, any>, For
         value={props.query.format}
         onChange={onChangeFormat}
         className="width-12"
+        menuShouldPortal={true}
       />
     </InlineField>
   );

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -118,6 +118,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
           className={props.className || 'min-width-6'}
           disabled={props.disabled}
           onOpenMenu={() => props.fetch && onClick()}
+          menuShouldPortal={true}
         />
       </div>
     </InlineField>


### PR DESCRIPTION
When running the tests we had a few warnings :

``` 
[Deprecation warning] SelectBase: menuShouldPortal={false} is deprecated. Use menuShouldPortal={true} instead
```

This PR fixes these warnings 🙂  using recommendations here: https://github.com/grafana/grafana/issues/42359#issuecomment-1032179575