### PR TITLE
Add SIGV4 wrapper component

### DIFF
--- a/src/SIGV4ConnectionConfig.test.tsx
+++ b/src/SIGV4ConnectionConfig.test.tsx
@@ -1,6 +1,6 @@
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { SIGV4ConnectionConfig } from 'SIGV4ConnectionConfig';
 import { AwsAuthType } from 'types';
 

--- a/src/SIGV4ConnectionConfig.test.tsx
+++ b/src/SIGV4ConnectionConfig.test.tsx
@@ -1,0 +1,97 @@
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SIGV4ConnectionConfig } from 'SIGV4ConnectionConfig';
+import { AwsAuthType } from 'types';
+
+const resetWindow = () => {
+  (window as any).grafanaBootData = {
+    settings: {
+      awsAllowedAuthProviders: [AwsAuthType.Credentials, AwsAuthType.Keys],
+      awsAssumeRoleEnabled: true,
+    },
+  };
+};
+
+describe('SIGV4ConnectionConfig', () => {
+  const setup = (onOptionsChange?: () => {}) => {
+    const props: DataSourcePluginOptionsEditorProps<any, any> = {
+      options: {
+        typeName: '',
+        id: 449,
+        uid: 'oIoBsD_Mz',
+        orgId: 1,
+        name: 'Elasticsearch',
+        type: 'elasticsearch',
+        typeLogoUrl: '',
+        access: 'proxy',
+        url: 'http://test.ts',
+        password: '',
+        user: '',
+        database: '',
+        basicAuth: false,
+        basicAuthUser: '',
+        basicAuthPassword: '',
+        withCredentials: false,
+        isDefault: false,
+        jsonData: {
+          esVersion: '7.10.0',
+          includeFrozen: false,
+          logLevelField: '',
+          logMessageField: '',
+          maxConcurrentShardRequests: 5,
+          sigV4AssumeRoleArn: 'arn:test',
+          sigV4Auth: true,
+          sigV4AuthType: 'credentials',
+          sigV4ExternalId: 'test-id',
+          sigV4Profile: 'profile',
+          sigV4Region: 'us-east-2',
+          timeField: '@timestamp',
+        },
+        secureJsonFields: { sigV4AccessKey: true, sigV4SecretKey: true },
+        version: 6,
+        readOnly: false,
+      },
+      onOptionsChange: onOptionsChange ?? jest.fn(),
+    };
+
+    render(<SIGV4ConnectionConfig {...props} />);
+  };
+
+  beforeEach(() => resetWindow());
+  afterEach(() => resetWindow());
+
+  it('should map incoming props correctly', () => {
+    setup();
+    expect(screen.getByText('Credentials file')).toBeInTheDocument();
+    expect(screen.getByLabelText('Assume Role ARN')).toHaveValue('arn:test');
+    expect(screen.getByLabelText('External ID')).toHaveValue('test-id');
+  });
+
+  it('should map changed fields correctly', async () => {
+    const onOptionsChange = jest.fn();
+    setup(onOptionsChange);
+
+    const labelElement = screen.getByLabelText('Assume Role ARN');
+    expect(labelElement).toBeInTheDocument();
+    fireEvent.change(labelElement, { target: { value: 'changed-arn' } });
+
+    const externalIdElement = screen.getByLabelText('External ID');
+    expect(externalIdElement).toBeInTheDocument();
+    fireEvent.change(externalIdElement, { target: { value: 'changed-test-id' } });
+
+    const authTypeElement = screen.getByLabelText('Authentication Provider');
+    expect(authTypeElement).toBeInTheDocument();
+    fireEvent.change(authTypeElement, { target: { value: 'keys' } });
+
+    expect.objectContaining({
+      options: expect.objectContaining({
+        jsonData: expect.objectContaining({
+          sigV4AssumeRoleArn: 'changed-arn',
+          sigV4ExternalId: 'changed-test-id',
+          sigV4AuthType: 'keys',
+        }),
+      }),
+    });
+  });
+});

--- a/src/SIGV4ConnectionConfig.tsx
+++ b/src/SIGV4ConnectionConfig.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
+import { ConnectionConfig, ConnectionConfigProps } from './ConnectionConfig';
+
+import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from './types';
+
+export const SIGV4ConnectionConfig: React.FC<DataSourcePluginOptionsEditorProps<any, any>> = (
+  props: DataSourcePluginOptionsEditorProps<any, any>
+) => {
+  console.log('sigv4', props);
+  const { onOptionsChange, options } = props;
+
+  // Map HttpSettings props to ConnectionConfigProps
+  const connectionConfigProps: ConnectionConfigProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> = {
+    onOptionsChange: (awsDataSourceSettings) => {
+      const dataSourceSettings: DataSourceSettings<any, any> = {
+        ...options,
+        jsonData: {
+          ...options.jsonData,
+          sigV4AuthType: awsDataSourceSettings.jsonData.authType,
+          sigV4Profile: awsDataSourceSettings.jsonData.profile,
+          sigV4AssumeRoleArn: awsDataSourceSettings.jsonData.assumeRoleArn,
+          sigV4ExternalId: awsDataSourceSettings.jsonData.externalId,
+          sigV4Region: awsDataSourceSettings.jsonData.defaultRegion,
+          sigV4Endpoint: awsDataSourceSettings.jsonData.endpoint,
+        },
+        secureJsonFields: {
+          sigV4AccessKey: awsDataSourceSettings.secureJsonFields?.accessKey,
+          sigV4SecretKey: awsDataSourceSettings.secureJsonFields?.secretKey,
+        },
+        secureJsonData: {
+          sigV4AccessKey: awsDataSourceSettings.secureJsonData?.accessKey,
+          sigV4SecretKey: awsDataSourceSettings.secureJsonData?.secretKey,
+        },
+      };
+      onOptionsChange(dataSourceSettings);
+    },
+    options: {
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        authType: options.jsonData.sigV4AuthType,
+        profile: options.jsonData.sigV4Profile,
+        assumeRoleArn: options.jsonData.sigV4AssumeRoleArn,
+        externalId: options.jsonData.sigV4ExternalId,
+        defaultRegion: options.jsonData.sigV4Region,
+        endpoint: options.jsonData.sigV4Endpoint,
+      },
+      secureJsonFields: {
+        accessKey: options.secureJsonFields?.sigV4AccessKey,
+        secretKey: options.secureJsonFields?.sigV4SecretKey,
+      },
+      secureJsonData: {
+        accessKey: options.secureJsonData?.sigV4AccessKey,
+        secretKey: options.secureJsonData?.sigV4SecretKey,
+      },
+    },
+  };
+
+  return (
+    <>
+      <div className="gf-form">
+        <h6>SigV4 Auth Details</h6>
+      </div>
+      <ConnectionConfig {...connectionConfigProps} skipHeader skipEndpoint></ConnectionConfig>
+    </>
+  );
+};

--- a/src/SIGV4ConnectionConfig.tsx
+++ b/src/SIGV4ConnectionConfig.tsx
@@ -7,7 +7,6 @@ import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from './ty
 export const SIGV4ConnectionConfig: React.FC<DataSourcePluginOptionsEditorProps<any, any>> = (
   props: DataSourcePluginOptionsEditorProps<any, any>
 ) => {
-  console.log('sigv4', props);
   const { onOptionsChange, options } = props;
 
   // Map HttpSettings props to ConnectionConfigProps

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { ConnectionConfig, ConnectionConfigProps } from './ConnectionConfig';
+export { SIGV4ConnectionConfig } from './SIGV4ConnectionConfig';
 export { ConfigSelect, InlineInput } from './sql/ConfigEditor';
 export { ResourceSelector, ResourceSelectorProps } from './sql/ResourceSelector';
 export { SQLQuery } from './sql/types';


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/43559

This PR moves the [`SIGV4ConnectionConfig`](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/DataSourceSettings/SigV4AuthSettings.tsx) from grafana to this repo where it belongs. The `SIGV4ConnectionConfig` is basically a wrapper around the `ConnectionConfig` component, making sure prop names are mapped properly. Unfortunately sigv4 props are not types in core grafana, hence all the tests for the mapping of the props.  