### PR TITLE
Fix issue with config select dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## next
+
+- Fix config selector bug for refetching credentials on dependency change.
+- Start contributing docs
+
 ## v0.0.36
 
 - Expose SIGV4 component

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## next
+## v0.0.37
 
 - Fix config selector bug for refetching credentials on dependency change.
 - Start contributing docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,5 @@ Want to install this repo locally?
     - back in aws-sdk run `yarn link` copy the instructions
     - run those instructions in the external consumer (athena)
   - if you got back a yarn version >2:
+  - if you get a yarn version >2:
     - in consumer package (ex grafana) `yarn link path-to-sdk` it should add a portal resolution to your package.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing Docs
+
+## Local Dev
+
+Want to install this repo locally?
+
+- In the terminal where this repo is installed: `yarn run dev` or `yarn run build`
+- In a terminal navigate to your consumer directory (ex athena) and run `yarn --version`
+  - if you get a yarn version <2:
+    - back in aws-sdk run `yarn link` copy the instructions
+    - run those instructions in the external consumer (athena)
+  - if you got back a yarn version >2:
+    - in consumer package (ex grafana) `yarn link path-to-sdk` it should add a portal resolution to your package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "scripts": {

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -53,6 +53,8 @@ export function ConfigSelect(props: ConfigSelectProps) {
     props.options.jsonData.endpoint,
     props.options.jsonData.externalId,
     props.options.jsonData.profile,
+    props.options.secureJsonData?.accessKey,
+    props.options.secureJsonData?.secretKey,
   ].concat(props.dependencies);
   return (
     <ResourceSelector

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@grafana/tsconfig/base.json",
   "include": ["src", "index.js"],
   "compilerOptions": {
-    "jsx": "react",
     "rootDir": "./src",
     "baseUrl": "./src",
     "typeRoots": ["./node_modules/@types"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@grafana/tsconfig/base.json",
   "include": ["src", "index.js"],
   "compilerOptions": {
+    "jsx": "react",
     "rootDir": "./src",
     "baseUrl": "./src",
     "typeRoots": ["./node_modules/@types"],


### PR DESCRIPTION
Fixes https://github.com/grafana/athena-datasource/issues/144

We were missing the dependencies for access key and secret key which meant when these values updated, other select fields (such as catalog in athena) would not re-fetch as it didn't notice a change. 