### PR TITLE
Make onRunQuery optional

### DIFF
--- a/src/sql/QueryEditor/FillValueSelect.tsx
+++ b/src/sql/QueryEditor/FillValueSelect.tsx
@@ -26,7 +26,7 @@ export const SelectableFillValueOptions: Array<SelectableValue<FillValueOptions>
 export type FillValueSelectProps<TQuery extends DataQuery> = {
   query: TQuery;
   onChange: (value: TQuery) => void;
-  onRunQuery: () => void;
+  onRunQuery?: () => void;
 };
 
 export function FillValueSelect<TQuery extends DataQuery & Record<string, any>>(props: FillValueSelectProps<TQuery>) {
@@ -43,7 +43,7 @@ export function FillValueSelect<TQuery extends DataQuery & Record<string, any>>(
               // Keep the fillMode.value in case FillValueOptions.Value mode is selected back
               fillMode: { ...props.query.fillMode, mode: value },
             });
-            props.onRunQuery();
+            props.onRunQuery?.();
           }}
           className="width-12"
           menuShouldPortal={true}
@@ -64,7 +64,7 @@ export function FillValueSelect<TQuery extends DataQuery & Record<string, any>>(
                 },
               })
             }
-            onBlur={() => props.onRunQuery()}
+            onBlur={() => props.onRunQuery?.()}
           />
         </InlineField>
       )}

--- a/src/sql/QueryEditor/FormatSelect.tsx
+++ b/src/sql/QueryEditor/FormatSelect.tsx
@@ -6,7 +6,7 @@ export type FormatSelectProps<TQuery extends DataQuery, FormatOptions> = {
   query: TQuery;
   options: Array<SelectableValue<FormatOptions>>;
   onChange: (value: TQuery) => void;
-  onRunQuery: () => void;
+  onRunQuery?: () => void;
 };
 
 export function FormatSelect<TQuery extends DataQuery & Record<string, any>, FormatOptions>(
@@ -17,7 +17,7 @@ export function FormatSelect<TQuery extends DataQuery & Record<string, any>, For
       ...props.query,
       format: e.value || 0,
     });
-    props.onRunQuery();
+    props.onRunQuery?.();
   };
   return (
     <InlineField label="Format as" labelWidth={11}>


### PR DESCRIPTION
Prep work for long running queries. Makes onRunQuery an optional prop for SQL components.

This was previously merged in https://github.com/grafana/grafana-aws-sdk-react/pull/21, but that was reverted to extract the long running queries code into a separate library. This PR is for adding back in the work that is specific to this library.