### PR TITLE
UI: Add support for optional labelWidth prop in config components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.0.40
+
+- Add support for optional labelWidth prop in Config components
+
 ## v0.0.39
 
 - Updated grafana/ dependencies to 9.2.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -22,12 +22,13 @@ export interface ConnectionConfigProps<J = AwsAuthDataSourceJsonData, S = AwsAut
   skipHeader?: boolean;
   skipEndpoint?: boolean;
   children?: React.ReactNode;
+  labelWidth?: number;
 }
 
 export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionConfigProps) => {
   const [regions, setRegions] = useState((props.standardRegions || standardRegions).map(toOption));
   const { loadRegions, onOptionsChange, skipHeader = false, skipEndpoint = false } = props;
-  const options = props.options;
+  const { labelWidth = 28, options } = props;
   let profile = options.jsonData.profile;
   if (profile === undefined) {
     profile = options.database;
@@ -67,7 +68,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     <FieldSet label={skipHeader ? '' : 'Connection Details'} data-testid="connection-config">
       <InlineField
         label="Authentication Provider"
-        labelWidth={28}
+        labelWidth={labelWidth}
         tooltip="Specify which AWS credentials chain to use."
       >
         <Select
@@ -85,7 +86,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       {options.jsonData.authType === 'credentials' && (
         <InlineField
           label="Credentials Profile Name"
-          labelWidth={28}
+          labelWidth={labelWidth}
           tooltip="Credentials profile name, as specified in ~/.aws/credentials, leave blank for default."
         >
           <Input
@@ -100,7 +101,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
 
       {options.jsonData.authType === 'keys' && (
         <>
-          <InlineField label="Access Key ID" labelWidth={28}>
+          <InlineField label="Access Key ID" labelWidth={labelWidth}>
             {props.options.secureJsonFields?.accessKey ? (
               <ButtonGroup className="width-30">
                 <Input disabled placeholder="Configured" />
@@ -121,7 +122,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
             )}
           </InlineField>
 
-          <InlineField label="Secret Access Key" labelWidth={28}>
+          <InlineField label="Secret Access Key" labelWidth={labelWidth}>
             {props.options.secureJsonFields?.secretKey ? (
               <ButtonGroup className="width-30">
                 <Input disabled placeholder="Configured" />
@@ -148,7 +149,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         <>
           <InlineField
             label="Assume Role ARN"
-            labelWidth={28}
+            labelWidth={labelWidth}
             tooltip="Optionally, specify the ARN of a role to assume. Specifying a role here will ensure that the selected authentication provider is used to assume the specified role rather than using the credentials directly. Leave blank if you don't need to assume a role at all"
           >
             <Input
@@ -161,7 +162,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
           </InlineField>
           <InlineField
             label="External ID"
-            labelWidth={28}
+            labelWidth={labelWidth}
             tooltip="If you are assuming a role in another account, that has been created with an external ID, specify the external ID here."
           >
             <Input
@@ -175,7 +176,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         </>
       )}
       {!skipEndpoint && (
-        <InlineField label="Endpoint" labelWidth={28} tooltip="Optionally, specify a custom endpoint for the service">
+        <InlineField label="Endpoint" labelWidth={labelWidth} tooltip="Optionally, specify a custom endpoint for the service">
           <Input
             aria-label="Endpoint"
             className="width-30"
@@ -187,7 +188,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       )}
       <InlineField
         label="Default Region"
-        labelWidth={28}
+        labelWidth={labelWidth}
         tooltip="Specify the region, such as for US West (Oregon) use ` us-west-2 ` as the region."
       >
         <Select

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -176,7 +176,11 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         </>
       )}
       {!skipEndpoint && (
-        <InlineField label="Endpoint" labelWidth={labelWidth} tooltip="Optionally, specify a custom endpoint for the service">
+        <InlineField
+          label="Endpoint"
+          labelWidth={labelWidth}
+          tooltip="Optionally, specify a custom endpoint for the service"
+        >
           <Input
             aria-label="Endpoint"
             className="width-30"

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -36,13 +36,15 @@ export interface ConfigSelectProps
   placeholder?: string;
   width?: number;
   isOptionDisabled?: () => boolean;
+  labelWidth?: number;
+
 }
 
 export function ConfigSelect(props: ConfigSelectProps) {
   const { jsonData } = props.options;
   const commonProps = {
     title: jsonData.defaultRegion ? '' : 'select a default region',
-    labelWidth: 28,
+    labelWidth: props.labelWidth ?? 28,
     className: 'width-30',
   };
   // Any change in the AWS connection details will affect selectors

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -37,7 +37,6 @@ export interface ConfigSelectProps
   width?: number;
   isOptionDisabled?: () => boolean;
   labelWidth?: number;
-
 }
 
 export function ConfigSelect(props: ConfigSelectProps) {

--- a/src/sql/ConfigEditor/InlineInput.tsx
+++ b/src/sql/ConfigEditor/InlineInput.tsx
@@ -13,13 +13,14 @@ export interface InlineInputProps extends DataSourcePluginOptionsEditorProps<{},
   'data-testid'?: string;
   hidden?: boolean;
   disabled?: boolean;
+  labelWidth?: number;
 }
 
 export function InlineInput(props: InlineInputProps) {
   return (
     <InlineField
       label={props.label}
-      labelWidth={28}
+      labelWidth={props.labelWidth ?? 28}
       tooltip={props.tooltip}
       hidden={props.hidden}
       disabled={props.disabled}


### PR DESCRIPTION
Originally a fix matching the width of all labels in Cloudwatch as a result of increasing "Namespaces" label here: 
<img width="420" alt="Screen Shot 2022-12-13 at 3 02 12 PM" src="https://user-images.githubusercontent.com/16140639/207361847-d9724bd3-7639-4b80-9d21-73ad6828fd52.png">

Added support for passing optional labelWidth, with default value set to the old {28} so all repos using this component don't have to make the change unless necessary. 


