### PR TITLE
Make ResourceSelector label prop required

### DIFF
--- a/src/sql/ConfigEditor/ConfigSelect.test.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.test.tsx
@@ -6,6 +6,7 @@ import { select } from 'react-select-event';
 
 const props: ConfigSelectProps = {
   ...mockDatasourceOptions,
+  label: 'label',
   value: 'foo',
   onChange: jest.fn(),
   fetch: jest.fn(),

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -10,7 +10,7 @@ export interface ConfigSelectProps
   fetch: () => Promise<Array<string | SelectableValue<string>>>;
   onChange: (e: SelectableValue<string> | null) => void;
   dependencies?: string[];
-  label?: string;
+  label: string;
   'data-testid'?: string;
   hidden?: boolean;
   disabled?: boolean;

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -9,7 +9,7 @@ export interface ResourceSelectorProps extends SelectCommonProps<string> {
   value: string | null;
   dependencies?: Array<string | null | undefined>;
   tooltip?: string;
-  label?: string;
+  label: string;
   'data-testid'?: string;
   hidden?: boolean;
   // Options only needed for QueryEditor


### PR DESCRIPTION
Makes the `ResourceSelector`'s `label` prop required.

This was split out as a piece of work from https://github.com/grafana/grafana-aws-sdk-react/pull/33/files#r1044841576.

- ResourceSelector usages https://github.com/search?q=org%3Agrafana+ResourceSelector+language%3ATSX&type=code&l=TSX
- ConfigSelector usages https://github.com/search?q=org%3Agrafana+ConfigSelect+language%3ATSX&type=code&l=TSX (ConfigSelector uses ResourceSelector).
Note these components are only used by Athena, Redshift, and Timestream. But I ran `yarn build` on all of the AWS data sources to check that there are no type errors.