### PR TITLE
UI: Export default label width for Configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+## v0.0.42
+
+- Export DEFAULT_LABEL_WIDTH for Config Editor components
 
 ## v0.0.41
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -12,6 +12,7 @@ import { standardRegions } from './regions';
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData, AwsAuthType } from './types';
 import { awsAuthProviderOptions } from './providers';
 
+export const DEFAULT_LABEL_WIDTH = 28;
 const toOption = (value: string) => ({ value, label: value });
 
 export interface ConnectionConfigProps<
@@ -30,7 +31,7 @@ export interface ConnectionConfigProps<
 export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionConfigProps) => {
   const [regions, setRegions] = useState((props.standardRegions || standardRegions).map(toOption));
   const { loadRegions, onOptionsChange, skipHeader = false, skipEndpoint = false } = props;
-  const { labelWidth = 28, options } = props;
+  const { labelWidth = DEFAULT_LABEL_WIDTH, options } = props;
   let profile = options.jsonData.profile;
   if (profile === undefined) {
     profile = options.database;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { ConnectionConfig, type ConnectionConfigProps } from './ConnectionConfig';
+export { ConnectionConfig, type ConnectionConfigProps, DEFAULT_LABEL_WIDTH } from './ConnectionConfig';
 export { SIGV4ConnectionConfig } from './SIGV4ConnectionConfig';
 export { ConfigSelect, InlineInput } from './sql/ConfigEditor';
 export { ResourceSelector, type ResourceSelectorProps } from './sql/ResourceSelector';

--- a/src/sql/ConfigEditor/ConfigSelect.tsx
+++ b/src/sql/ConfigEditor/ConfigSelect.tsx
@@ -3,6 +3,7 @@ import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/da
 import { InputActionMeta } from '@grafana/ui';
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '../../types';
 import { ResourceSelector } from '../ResourceSelector';
+import { DEFAULT_LABEL_WIDTH } from '../../ConnectionConfig';
 
 export interface ConfigSelectProps
   extends DataSourcePluginOptionsEditorProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> {
@@ -43,7 +44,7 @@ export function ConfigSelect(props: ConfigSelectProps) {
   const { jsonData } = props.options;
   const commonProps = {
     title: jsonData.defaultRegion ? '' : 'select a default region',
-    labelWidth: props.labelWidth ?? 28,
+    labelWidth: props.labelWidth ?? DEFAULT_LABEL_WIDTH,
     className: 'width-30',
   };
   // Any change in the AWS connection details will affect selectors

--- a/src/sql/ConfigEditor/InlineInput.tsx
+++ b/src/sql/ConfigEditor/InlineInput.tsx
@@ -3,6 +3,7 @@ import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { AwsAuthDataSourceSecureJsonData } from '../../types';
 import { InlineField, Input } from '@grafana/ui';
 import { FormEvent } from 'react-dom/node_modules/@types/react';
+import { DEFAULT_LABEL_WIDTH } from '../../ConnectionConfig';
 
 export interface InlineInputProps extends DataSourcePluginOptionsEditorProps<{}, AwsAuthDataSourceSecureJsonData> {
   value: string;
@@ -20,7 +21,7 @@ export function InlineInput(props: InlineInputProps) {
   return (
     <InlineField
       label={props.label}
-      labelWidth={props.labelWidth ?? 28}
+      labelWidth={props.labelWidth ?? DEFAULT_LABEL_WIDTH}
       tooltip={props.tooltip}
       hidden={props.hidden}
       disabled={props.disabled}


### PR DESCRIPTION
Small improvement on this one: https://github.com/grafana/grafana-aws-sdk-react/pull/34
With this, config editors in other plugins can add additional input fields and make sure they're the same default width as the rest coming from sdk-react.