### PR TITLE
Fix yarn dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "scripts": {
-    "dev": "yarn bundle --watch",
+    "dev": "yarn bundle --watch --watch.onStart=\"yarn typecheck\"",
     "build": "yarn clean && yarn typecheck && yarn bundle",
     "bundle": "rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -40,5 +40,8 @@ export default [
       file: pkg.publishConfig.types,
       format: 'es',
     },
+    watch: {
+      exclude: './compiled/**',
+    },
   },
 ];


### PR DESCRIPTION
- add `--watch.onStart=\"yarn typecheck\"` to ensure ./compiled types are available when running `yarn dev`. Previously a clean repo would throw an error unless `yarn typecheck` was not run before `yarn dev`