### PR TITLE
Chore: Move PublishConfig properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "version": "0.0.44",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/index.d.ts",
   "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/esm/index.js",
-    "types": "dist/index.d.ts",
     "access": "public"
   },
   "scripts": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -23,12 +23,12 @@ export default [
       {
         format: 'cjs',
         sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.main),
+        dir: path.dirname(pkg.main),
       },
       {
         format: 'esm',
         sourcemap: true,
-        dir: path.dirname(pkg.publishConfig.module),
+        dir: path.dirname(pkg.module),
         preserveModules: true,
       },
     ],
@@ -37,7 +37,7 @@ export default [
     input: './compiled/index.d.ts',
     plugins: [dts()],
     output: {
-      file: pkg.publishConfig.types,
+      file: pkg.types,
       format: 'es',
     },
     watch: {


### PR DESCRIPTION
I noticed you're making use of publishConfig to set package.json properties which is only supported by [yarn berry](https://yarnpkg.com/configuration/manifest/#publishConfig) and [pnpm](https://pnpm.io/package_json#publishconfig). 

Given the package.json always points at dist there's no need to migrate to either of these package managers and we can move the properties out to allow consuming projects to make use of the esm builds.