### PR TITLE
Move state variable from state to ref to prevent infinite loop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,6 @@ Want to install this repo locally?
 
 Ready to release a new version?
 
-- create a pr and update the package.json and changelog to be how you'd like
-- merge the pr, that's it! (get's published to npm via https://github.com/grafana/grafana-aws-sdk-react/blob/main/.github/workflows/publish-npm.yml)
+- create a pr and update the package.json with the new version, as well as the changelog to be how you'd like
+- merge the pr, that's it! (the change in the version triggers a publish to npm via https://github.com/grafana/grafana-aws-sdk-react/blob/main/.github/workflows/publish-npm.yml)
 - a note we don't currently make tags/releases on github, but perhaps in the future we can do so

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -79,7 +79,6 @@ export function ResourceSelector(props: ResourceSelectorProps) {
       resource.current = null;
       dependencies.current = propsDependencies
       propsOnChange(null);
-    ;
     }
   }, [propsDependencies, propsOnChange]);
 

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -82,7 +82,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
     ;
     }
   }, [propsDependencies, propsOnChange]);
-  
+
   const fetch = async () => {
     if (fetched.current) {
       return;
@@ -99,7 +99,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
   };
 
   const onChange = (e: SelectableValue<string>) => {
-    props.onChange(e);
+    propsOnChange(e);
     if (e.value) {
       resource.current = e.value;
     }

--- a/src/sql/ResourceSelector.tsx
+++ b/src/sql/ResourceSelector.tsx
@@ -31,7 +31,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
   const dependencies = useRef(props.dependencies);
   const fetched = useRef<boolean>(false);
   const resource = useRef<string | null>(props.value || props.default || null);
-  
+
   const [resources, setResources] = useState<Array<string | SelectableValue>>(
     resource.current ? [resource.current] : []
   );
@@ -82,8 +82,7 @@ export function ResourceSelector(props: ResourceSelectorProps) {
     ;
     }
   }, [propsDependencies, propsOnChange]);
-
-  console.log('cccompiles!');
+  
   const fetch = async () => {
     if (fetched.current) {
       return;


### PR DESCRIPTION
This is a fix for an bug with stack overflow in Athena and Redshift that happened when updating grafana to React 18, described [here](https://github.com/grafana/oss-plugin-partnerships/issues/163). 

I wish I could say with any kind of authority why this happened in the first place, and only in variable editor. @sarahzinger already described here that the problem is [in this useEffect](https://github.com/grafana/grafana-aws-sdk-react/blob/926a5dc067d355f682f965f777834668dd78789f/src/sql/ResourceSelector.tsx#L67): 
`
if (!isEqual(props.dependencies, dependencies)) {
      setFetched(false);
      setResource(null);
      props.onChange(null);
      setDependencies(props.dependencies);
`

After debugging, it looks like the 
1. props.query gets updated from props.onChange(null) BEFORE  setDependencies(props.dependencies) is evaluated. 
2. This triggers another run of the useEffect without the `dependencies` state variable having been updated to their latest value. This means the value is always undefined at the point when this effect runs. 

That doesn't explain why it only happened in variable editor and not in panels though, but React's batching 🤷🏻‍♀️ amirite? 😞

I wanted to clean up the state and this effect a bit before I tackled the batching problem, so I followed what is usually recommended in the case of infinite useEffect loops, which is to reevaluate which variables are stored as state variables, and which are just refs. I moved basically all of them from this useEffect (`fetched, resource, and dependencies`) since they didn't need to be state variables and changes to them shouldn't cause a rerender (AFAI can see).

Aaand this ended up actually fixing the problem! It's the `dependencies` variable being changed to a ref that did it I think, I assume because it's no longer a state variable, it wasn't being updated (well, NOT updated) asynchronously?
Also, interestingly, if you replace this non-working useEffect with useLayoutEffect it works fine. Maybe it has to do with the synchronicity of useLayoutEffect, but my brain is fried and I welcome someone taking over the thinking for this, if you wish. 

This might not be solving an overreaching problem, since I don't know the details of what caused it and in which cases. Im ok with hoping it doesn't happen again by being careful with what we put into state variables when there are a lot of moving parts (like here) from React@18 up. 


I also made a small change in CONTRIBUTING.md