### PR TITLE
Support numeric values when applying template variables to SQL queries

### DIFF
--- a/src/sql/utils/utils.test.ts
+++ b/src/sql/utils/utils.test.ts
@@ -12,6 +12,7 @@ describe('filterQuery', () => {
 
 const scopedVars: Record<string, any> = {
   $simple: 'foo',
+  $numeric: 123,
   $multiple: ['foo', 'bar'],
 };
 // simplified version of getTemplateSrv().replace
@@ -33,6 +34,15 @@ describe('applySQLTemplateVariables', () => {
       getTemplateSrv
     );
     expect(res.rawSQL).toEqual('select * from foo');
+  });
+
+  it('should replace a numeric var', () => {
+    const res = applySQLTemplateVariables(
+      { ...mockQuery, rawSQL: 'select * from $numeric' },
+      scopedVars,
+      getTemplateSrv
+    );
+    expect(res.rawSQL).toEqual('select * from 123');
   });
 
   it('should replace a multiple var', () => {

--- a/src/sql/utils/utils.ts
+++ b/src/sql/utils/utils.ts
@@ -22,7 +22,7 @@ export function applySQLTemplateVariables(
 }
 
 function interpolateVariable(value: string | string[]) {
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || typeof value === 'number') {
     return value;
   }
 


### PR DESCRIPTION
Numeric template variable values cause an error in the SQL data sources. E.g. `select $__interval_ms` would throw an error.