### PR TITLE
Use @grafana/runtime instead of grafanaBootData

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -13,7 +13,7 @@ export default [
     plugins: [
       externals({
         deps: true,
-        include: ['react', '@grafana/data', '@grafana/ui', 'lodash'],
+        include: ['react', '@grafana/data', '@grafana/ui', '@grafana/runtime', 'lodash'],
         packagePath,
       }),
       resolve(),

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -55,9 +55,6 @@ const getProps = (propOverrides?: object) => {
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   config: {
-    featureToggles: {
-      awsDatasourcesTempCredentials: true,
-    },
     awsAllowedAuthProviders: [AwsAuthType.EC2IAMRole, AwsAuthType.Keys],
     awsAssumeRoleEnabled: false
   },
@@ -65,7 +62,6 @@ jest.mock('@grafana/runtime', () => ({
 
 describe('ConnectionConfig', () => {
   beforeEach(() => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
     config.awsAllowedAuthProviders = [AwsAuthType.EC2IAMRole, AwsAuthType.Keys];
   });
   it('should use auth type from props if its set', async () => {

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -63,6 +63,7 @@ jest.mock('@grafana/runtime', () => ({
 describe('ConnectionConfig', () => {
   beforeEach(() => {
     config.awsAllowedAuthProviders = [AwsAuthType.EC2IAMRole, AwsAuthType.Keys];
+    config.awsAssumeRoleEnabled = false;
   });
   it('should use auth type from props if its set', async () => {
     const onOptionsChange = jest.fn();

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -59,6 +59,7 @@ jest.mock('@grafana/runtime', () => ({
       awsDatasourcesTempCredentials: true,
     },
     awsAllowedAuthProviders: [AwsAuthType.EC2IAMRole, AwsAuthType.Keys],
+    awsAssumeRoleEnabled: false
   },
 }));
 
@@ -84,7 +85,7 @@ describe('ConnectionConfig', () => {
 
     const optionsConfig = props.options;
     expect(onOptionsChange).toHaveBeenCalledWith({
-      ...config,
+      ...optionsConfig,
       jsonData: {
         ...optionsConfig.jsonData,
         authType: AwsAuthType.EC2IAMRole,

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -14,7 +14,9 @@ import { awsAuthProviderOptions } from './providers';
 
 export const DEFAULT_LABEL_WIDTH = 28;
 const toOption = (value: string) => ({ value, label: value });
-
+const isAwsAuthType = (value: any): value is AwsAuthType => {
+  return typeof value === 'string' && awsAuthProviderOptions.some((opt) => opt.value === value);
+}
 export interface ConnectionConfigProps<
   J extends AwsAuthDataSourceJsonData = AwsAuthDataSourceJsonData,
   S = AwsAuthDataSourceSecureJsonData
@@ -38,10 +40,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   }
   
   const awsAssumeRoleEnabled = config.awsAssumeRoleEnabled
-  const awsAllowerProvidersConfig = config.awsAllowedAuthProviders as AwsAuthType[]
   const awsAllowedAuthProviders = useMemo(
-    () => awsAllowerProvidersConfig,
-    [awsAllowerProvidersConfig]
+    () => config.awsAllowedAuthProviders.filter(isAwsAuthType),
+    []
   );
 
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -78,7 +78,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
           aria-label="Authentication Provider"
           className="width-30"
           value={currentProvider}
-          options={awsAuthProviderOptions.filter((opt) => opt.value && awsAllowedAuthProviders.includes(opt.value))}
+          options={awsAuthProviderOptions.filter((opt) => awsAllowedAuthProviders.includes(opt.value!))}
           defaultValue={options.jsonData.authType}
           onChange={(option) => {
             onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -36,15 +36,12 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   if (profile === undefined) {
     profile = options.database;
   }
-
-  const settings = (window as any).grafanaBootData.settings;
   
   const awsAssumeRoleEnabled = config.awsAssumeRoleEnabled
-  const tempCredsFeatureEnabled = config.featureToggles.awsDatasourcesTempCredentials;
   const awsAllowerProvidersConfig = config.awsAllowedAuthProviders as AwsAuthType[]
   const awsAllowedAuthProviders = useMemo(
-    () => awsAllowerProvidersConfig.filter((option: AwsAuthType) => (option === AwsAuthType.GrafanaAssumeRole ? tempCredsFeatureEnabled : true)),
-    [awsAllowerProvidersConfig, tempCredsFeatureEnabled]
+    () => awsAllowerProvidersConfig,
+    [awsAllowerProvidersConfig]
   );
 
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);

--- a/src/SIGV4ConnectionConfig.test.tsx
+++ b/src/SIGV4ConnectionConfig.test.tsx
@@ -1,19 +1,23 @@
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { SIGV4ConnectionConfig } from 'SIGV4ConnectionConfig';
-import { AwsAuthType } from 'types';
+import { AwsAuthType } from './types';
+import { SIGV4ConnectionConfig } from './SIGV4ConnectionConfig';
+import {config} from '@grafana/runtime'
 
-const resetWindow = () => {
-  (window as any).grafanaBootData = {
-    settings: {
-      awsAllowedAuthProviders: [AwsAuthType.Credentials, AwsAuthType.Keys],
-      awsAssumeRoleEnabled: true,
-    },
-  };
-};
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    awsAllowedAuthProviders: [AwsAuthType.Credentials, AwsAuthType.Keys],
+    awsAssumeRoleEnabled: true,
+  },
+}));
 
 describe('SIGV4ConnectionConfig', () => {
+  beforeEach(() => {
+    config.awsAllowedAuthProviders = [AwsAuthType.Credentials, AwsAuthType.Keys];
+    config.awsAssumeRoleEnabled = true;
+  });
   const setup = (onOptionsChange?: () => {}) => {
     const props: DataSourcePluginOptionsEditorProps<any, any> = {
       options: {
@@ -55,9 +59,6 @@ describe('SIGV4ConnectionConfig', () => {
 
     render(<SIGV4ConnectionConfig {...props} />);
   };
-
-  beforeEach(() => resetWindow());
-  afterEach(() => resetWindow());
 
   it('should map incoming props correctly', () => {
     setup();


### PR DESCRIPTION
This was started as a refactor of ConnectionConfig to remove (window as any), but even though there was a [commit](https://github.com/grafana/grafana-aws-sdk-react/commit/ecf55d27751f4cf7bff0a948d6a5b893c5170dd9) by @sunker  that moved away from grafana/runtime to window.grafanaBootData (possibly because it was necessary for Grafana@7), I couldn't find a reason right now to not use config from runtime. 

1. One of the reasons /runtime.config seems a better solution is that [here](https://github.com/grafana/grafana/blob/92ef0e80ad0b5ebfc44c9d99eb6c001da257ffa8/packages/grafana-runtime/src/config.ts#L190) the `grafanaBootData`(`config`) is merged with defaults and with initial values from config.ts. 
This means that `awsAssumeRoleEnabled` and `awsAllowedAuthProviders` might not be defined in grafanaBootData, but instead in defaults for example, so it makes sense to read from a merged object (runtime.config) and not from grafanaBootData

2. I also decided to remove test cases that check if these fields are defined since we have some [code on the BE](https://github.com/grafana/grafana/blob/92ef0e80ad0b5ebfc44c9d99eb6c001da257ffa8/pkg/setting/setting.go#L1267) that takes care that both of these fields are defined and sets default values if they are not. So it looks to me that there is no way these fields could be undefined. This is also reflected in the types [here](https://github.com/grafana/grafana/blob/92ef0e80ad0b5ebfc44c9d99eb6c001da257ffa8/packages/grafana-runtime/src/config.ts#L123):
``` 
awsAllowedAuthProviders: string[] = [];
 awsAssumeRoleEnabled = false;
  ```
  
  Lmk if there's anything I missed about the context here! 