### PR TITLE
ConnectionConfig: update input width for experimental auth component

### DIFF
--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -71,6 +71,10 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     loadRegions().then((regions) => setRegions(regions.map(toOption)));
   }, [loadRegions]);
 
+  const inExperimentalAuthComponent = options.jsonData.inExperimentalAuthComponent;
+
+  const inputWidth = inExperimentalAuthComponent ? "width-20" : "width-30";
+
   return (
     <FieldSet label={skipHeader ? '' : 'Connection Details'} data-testid="connection-config">
       <InlineField
@@ -80,7 +84,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       >
         <Select
           aria-label="Authentication Provider"
-          className="width-30"
+          className={inputWidth}
           value={currentProvider}
           options={awsAuthProviderOptions.filter((opt) => awsAllowedAuthProviders.includes(opt.value!))}
           defaultValue={options.jsonData.authType}
@@ -98,7 +102,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         >
           <Input
             aria-label="Credentials Profile Name"
-            className="width-30"
+            className={inputWidth}
             placeholder="default"
             value={profile}
             onChange={onUpdateDatasourceJsonDataOption(props, 'profile')}
@@ -110,7 +114,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         <>
           <InlineField label="Access Key ID" labelWidth={labelWidth}>
             {props.options.secureJsonFields?.accessKey ? (
-              <ButtonGroup className="width-30">
+              <ButtonGroup className={inputWidth}>
                 <Input disabled placeholder="Configured" />
                 <ToolbarButton
                   icon="edit"
@@ -122,7 +126,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
             ) : (
               <Input
                 aria-label="Access Key ID"
-                className="width-30"
+                className={inputWidth}
                 value={options.secureJsonData?.accessKey ?? ''}
                 onChange={onUpdateDatasourceSecureJsonDataOption(props, 'accessKey')}
               />
@@ -131,7 +135,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
 
           <InlineField label="Secret Access Key" labelWidth={labelWidth}>
             {props.options.secureJsonFields?.secretKey ? (
-              <ButtonGroup className="width-30">
+              <ButtonGroup className={inputWidth}>
                 <Input disabled placeholder="Configured" />
                 <ToolbarButton
                   icon="edit"
@@ -143,7 +147,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
             ) : (
               <Input
                 aria-label="Secret Access Key"
-                className="width-30"
+                className={inputWidth}
                 value={options.secureJsonData?.secretKey ?? ''}
                 onChange={onUpdateDatasourceSecureJsonDataOption(props, 'secretKey')}
               />
@@ -161,7 +165,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
           >
             <Input
               aria-label="Assume Role ARN"
-              className="width-30"
+              className={inputWidth}
               placeholder="arn:aws:iam:*"
               value={options.jsonData.assumeRoleArn || ''}
               onChange={onUpdateDatasourceJsonDataOption(props, 'assumeRoleArn')}
@@ -175,7 +179,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
             >
               <Input
                 aria-label="External ID"
-                className="width-30"
+                className={inputWidth}
                 placeholder="External ID"
                 value={options.jsonData.externalId || ''}
                 onChange={onUpdateDatasourceJsonDataOption(props, 'externalId')}
@@ -192,7 +196,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         >
           <Input
             aria-label="Endpoint"
-            className="width-30"
+            className={inputWidth}
             placeholder={props.defaultEndpoint ?? 'https://{service}.{region}.amazonaws.com'}
             value={options.jsonData.endpoint || ''}
             onChange={onUpdateDatasourceJsonDataOption(props, 'endpoint')}
@@ -206,7 +210,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       >
         <Select
           aria-label="Default Region"
-          className="width-30"
+          className={inputWidth}
           value={regions.find((region) => region.value === options.jsonData.defaultRegion)}
           options={regions}
           defaultValue={options.jsonData.defaultRegion}

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -28,12 +28,17 @@ export interface ConnectionConfigProps<
   skipEndpoint?: boolean;
   children?: React.ReactNode;
   labelWidth?: number;
+  inExperimentalAuthComponent?: boolean;
 }
 
 export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionConfigProps) => {
   const [regions, setRegions] = useState((props.standardRegions || standardRegions).map(toOption));
   const { loadRegions, onOptionsChange, skipHeader = false, skipEndpoint = false } = props;
-  const { labelWidth = DEFAULT_LABEL_WIDTH, options } = props;
+  const { 
+    labelWidth = DEFAULT_LABEL_WIDTH, 
+    options, 
+    inExperimentalAuthComponent 
+  } = props;
   let profile = options.jsonData.profile;
   if (profile === undefined) {
     profile = options.database;
@@ -70,8 +75,6 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
 
     loadRegions().then((regions) => setRegions(regions.map(toOption)));
   }, [loadRegions]);
-
-  const inExperimentalAuthComponent = options.jsonData.inExperimentalAuthComponent;
 
   const inputWidth = inExperimentalAuthComponent ? "width-20" : "width-30";
 

--- a/src/SIGV4ConnectionConfig.tsx
+++ b/src/SIGV4ConnectionConfig.tsx
@@ -4,8 +4,12 @@ import { ConnectionConfig, ConnectionConfigProps } from './ConnectionConfig';
 
 import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from './types';
 
-export const SIGV4ConnectionConfig: React.FC<DataSourcePluginOptionsEditorProps<any, any>> = (
-  props: DataSourcePluginOptionsEditorProps<any, any>
+export interface SIGV4ConnectionConfigProps extends DataSourcePluginOptionsEditorProps<any, any> {
+  inExperimentalAuthComponent?: boolean;
+};
+
+export const SIGV4ConnectionConfig: React.FC<SIGV4ConnectionConfigProps> = (
+  props: SIGV4ConnectionConfigProps
 ) => {
   const { onOptionsChange, options } = props;
 
@@ -54,6 +58,7 @@ export const SIGV4ConnectionConfig: React.FC<DataSourcePluginOptionsEditorProps<
         secretKey: options.secureJsonData?.sigV4SecretKey,
       },
     },
+    inExperimentalAuthComponent: props.inExperimentalAuthComponent,
   };
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
   profile?: string; // Credentials profile name, as specified in ~/.aws/credentials
   defaultRegion?: string; // region if it is not defined by your credentials file
   endpoint?: string;
+  inExperimentalAuthComponent?: boolean;
 }
 
 export interface AwsAuthDataSourceSecureJsonData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,6 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
   profile?: string; // Credentials profile name, as specified in ~/.aws/credentials
   defaultRegion?: string; // region if it is not defined by your credentials file
   endpoint?: string;
-  inExperimentalAuthComponent?: boolean;
 }
 
 export interface AwsAuthDataSourceSecureJsonData {


### PR DESCRIPTION
**What is this?**
This is a small UI change, an update to the input widths for the connection config component, _only_ when it is inside the experimental auth component.

**Why is this needed?**
The experimental auth component is part of the Config Overhaul project and the Prometheus config has recently been updated to use the new auth component.

Here is what it looks like without the update:
![Screenshot 2023-07-26 at 8 56 23 AM](https://github.com/grafana/grafana-aws-sdk-react/assets/25674746/0f450dd3-c25a-4b5c-8ce9-afd2422d3127)

Here is what it looks like with the update:
![Screenshot 2023-07-26 at 11 51 28 AM](https://github.com/grafana/grafana-aws-sdk-react/assets/25674746/1e56ef55-3f9f-4785-b3da-53a7e3878d4b)

Notes for the reviewers:
Let me know if you have any questions or have any suggestions!

