### PR TITLE
Temp Credentials: Display External Id

### DIFF
--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -179,7 +179,8 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
             </li>
             <li>
               <p>
-                3. Enter the following external ID: <code>{props.externalId}</code> and click <code>Next</code>.
+                3. Enter the following external ID:{' '}
+                <code>{props.externalId || 'External Id is currently unavailable'}</code> and click <code>Next</code>.
               </p>
             </li>
             <li>


### PR DESCRIPTION
We could fix the UI a bit I think, but I think this is generally enough to get folks started. Also decided to hide the "endpoint" field in this auth flow because honestly I'm not sure if it will work or not it might make sense to only add that when we know it is supported. (I think it might be?? but I haven't tested it)

![Screenshot 2023-08-03 at 9 06 27 AM](https://github.com/grafana/grafana-aws-sdk-react/assets/6620164/fecd8478-cc10-4cff-b8ce-c609546b0587)
![Screenshot 2023-08-03 at 9 06 34 AM](https://github.com/grafana/grafana-aws-sdk-react/assets/6620164/030f3152-70c0-4135-8f6c-dcb47522176e)

To test out this flow you can run https://github.com/grafana/grafana/pull/72821 and install this plugin locally into grafana
