### PR TITLE
Add an option for deleting fields that contain empty string values in jsonData

### DIFF
--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -61,12 +61,14 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (value === '') {
       delete jsonData[key]
     }
-    const config = props.options;
+    else {
+      // @ts-ignore
+       jsonData[key] = value
+    }
     props.onOptionsChange({
-      ...config,
+      ...props.options,
       jsonData: {
-        ...config.jsonData,
-        [key]: value,
+        ...jsonData,
       },
     });
   };

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -53,6 +53,24 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
 
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);
 
+  //  use this when empty string value will cause bugs
+  const onUpdateOrDeleteDatasourceJsonData = (props: ConnectionConfigProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData>, key: keyof AwsAuthDataSourceJsonData) =>
+  (event: React.SyntheticEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const {jsonData}  = props.options
+    const {value} = event.currentTarget
+    if (value === '') {
+      delete jsonData[key]
+    }
+    const config = props.options;
+    props.onOptionsChange({
+      ...config,
+      jsonData: {
+        ...config.jsonData,
+        [key]: value,
+      },
+    });
+  };
+
   useEffect(() => {
     // Make sure a authType exists in the current model
     if (!currentProvider && awsAllowedAuthProviders.length) {
@@ -255,7 +273,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
             className={inputWidth}
             placeholder={props.defaultEndpoint ?? 'https://{service}.{region}.amazonaws.com'}
             value={options.jsonData.endpoint || ''}
-            onChange={onUpdateDatasourceJsonDataOption(props, 'endpoint')}
+            onChange={onUpdateOrDeleteDatasourceJsonData(props, 'endpoint')}
           />
         </InlineField>
       )}


### PR DESCRIPTION
When jsonData.endpoint is an empty string, we were experiencing bugs outlined in [this Twinmaker issue](https://github.com/grafana/grafana-iot-twinmaker-app/issues/203).  The bug could also be fixed in Twinmaker itself but I wonder if there are other places in which having an empty string endpoint would cause unexpected behaviors.

To reproduce, follow the steps [here](https://github.com/grafana/grafana-iot-twinmaker-app/issues/203#issuecomment-1660721032) and you should no longer see the error.