### PR TITLE
Only show grafana assume role on enabled datasources

### DIFF
--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -191,4 +191,23 @@ describe('ConnectionConfig', () => {
     expect(screen.getByText('Credentials file')).toBeInTheDocument();
     expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
   });
+  it('should not render GrafanaAssumeRole if the datasource is not a supported datasource type', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const props = getProps();
+    const overwriteOptions = { ...props.options, type: 'grafana-athena-datasource' };
+    render(<ConnectionConfig {...props} options={overwriteOptions} />);
+    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
+    expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
+  });
+
+  it('should render GrafanaAssumeRole if the datasource is a supported datasource type', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const props = getProps();
+    const overwriteOptions = { ...props.options, type: 'cloudwatch' };
+    render(<ConnectionConfig {...props} options={overwriteOptions} />);
+    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+  });
 });

--- a/src/ConnectionConfig.test.tsx
+++ b/src/ConnectionConfig.test.tsx
@@ -14,7 +14,7 @@ const getProps = (propOverrides?: object) => {
       uid: '',
       orgId: 1,
       name: 'aws-plugin-name',
-      type: 'aws',
+      type: 'aws-plugin-id',
       basicAuth: false,
       basicAuthUser: '',
       withCredentials: false,
@@ -174,6 +174,16 @@ describe('ConnectionConfig', () => {
 
     await waitFor(() => expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument());
   });
+  it('should render GrafanaAssumeRole as auth type if the feature flag is enabled and auth providers has GrafanaAssumeRole and the datasource supports temp credentials', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const props = getProps();
+    const overwriteOptions = { ...props.options, type: 'cloudwatch' };
+    render(<ConnectionConfig {...props} options={overwriteOptions} />);
+    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
+    expect(screen.getByText('Credentials file')).toBeInTheDocument();
+    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
+  });
   it('should not render GrafanaAssumeRole as auth type if the feature flag is not enabled', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = false;
     const props = getProps();
@@ -181,15 +191,6 @@ describe('ConnectionConfig', () => {
     await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
     expect(screen.getByText('Credentials file')).toBeInTheDocument();
     expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
-  });
-  it('should render GrafanaAssumeRole as auth type if the feature flag is enabled and auth providers has GrafanaAssumeRole', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const props = getProps();
-    render(<ConnectionConfig {...props} />);
-    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
-    expect(screen.getByText('Credentials file')).toBeInTheDocument();
-    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
   });
   it('should not render GrafanaAssumeRole if the datasource is not a supported datasource type', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
@@ -199,15 +200,5 @@ describe('ConnectionConfig', () => {
     render(<ConnectionConfig {...props} options={overwriteOptions} />);
     await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
     expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
-  });
-
-  it('should render GrafanaAssumeRole if the datasource is a supported datasource type', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const props = getProps();
-    const overwriteOptions = { ...props.options, type: 'cloudwatch' };
-    render(<ConnectionConfig {...props} options={overwriteOptions} />);
-    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
-    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
   });
 });

--- a/src/ConnectionConfig.tsx
+++ b/src/ConnectionConfig.tsx
@@ -13,6 +13,7 @@ import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData, AwsAuthType
 import { awsAuthProviderOptions } from './providers';
 
 export const DEFAULT_LABEL_WIDTH = 28;
+const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = ['cloudwatch'];
 const toOption = (value: string) => ({ value, label: value });
 const isAwsAuthType = (value: any): value is AwsAuthType => {
   return typeof value === 'string' && awsAuthProviderOptions.some((opt) => opt.value === value);
@@ -41,7 +42,8 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   if (profile === undefined) {
     profile = options.database;
   }
-  const tempCredsFeatureEnabled = config.featureToggles.awsDatasourcesTempCredentials;
+  const tempCredsFeatureEnabled =
+    config.featureToggles.awsDatasourcesTempCredentials && DS_TYPES_THAT_SUPPORT_TEMP_CREDS.includes(options.type);
   const awsAssumeRoleEnabled = config.awsAssumeRoleEnabled ?? true;
   const awsAllowedAuthProviders = useMemo(
     () =>


### PR DESCRIPTION
This pr will hide the temporary credentials ui unless the datasource is on a list of approved datasources. 

We had originally considered enabling temp credentials on all datasources at once, but for a smoother rollout it would be better if we did this gradually. Each datasource also currently needs to configure a way to access externalId through a resource endpoint (maybe in the future we could figure out a way to centralize this in one place, but for now this is per-datasource), so it would be better if we hide the UI until we have fully tested and ensured each datasource will work with temp credentials. 

