### PR TITLE
 Change "Run query" button to "Run queries"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 
+## v0.3.2
+
+- Change "Run query" button to "Run queries"
+
 ## v0.3.1
 
 - Add spellcheck script and drone step in [#67](https://github.com/grafana/grafana-aws-sdk-react/pull/67)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## v0.3.2
 
-- Change "Run query" button to "Run queries"
+- Change "Run query" button to "Run queries" im [#77](https://github.com/grafana/grafana-aws-sdk-react/pull/77)
 
 ## v0.3.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/sql/QueryEditor/QueryEditorHeader.test.tsx
+++ b/src/sql/QueryEditor/QueryEditorHeader.test.tsx
@@ -22,7 +22,7 @@ describe('QueryEditorHeader', () => {
   });
   it('should display just the run button if showAsyncQueryButtons prop is false', async () => {
     render(<QueryEditorHeader {...props} showAsyncQueryButtons={false} />);
-    const runButton = screen.getByRole('button', { name: 'Run query' });
+    const runButton = screen.getByRole('button', { name: 'Run queries' });
     const stopButton = screen.queryByRole('button', { name: 'Stop query' });
     expect(runButton).toBeInTheDocument();
     expect(stopButton).not.toBeInTheDocument();
@@ -30,7 +30,7 @@ describe('QueryEditorHeader', () => {
 
   it('run button should be disabled if enableButton prop is false', () => {
     render(<QueryEditorHeader {...props} enableRunButton={false} showAsyncQueryButtons={false} />);
-    const runButton = screen.getByRole('button', { name: 'Run query' });
+    const runButton = screen.getByRole('button', { name: 'Run queries' });
     expect(runButton).toBeDisabled();
   });
 
@@ -43,7 +43,7 @@ describe('QueryEditorHeader', () => {
         showAsyncQueryButtons={false}
       />
     );
-    const runButton = screen.getByRole('button', { name: 'Run query' });
+    const runButton = screen.getByRole('button', { name: 'Run queries' });
     expect(runButton).toBeDisabled();
   });
 
@@ -52,7 +52,7 @@ describe('QueryEditorHeader', () => {
     render(
       <QueryEditorHeader {...props} onRunQuery={onRunQuery} showAsyncQueryButtons={false} enableRunButton={true} />
     );
-    const runButton = screen.getByRole('button', { name: 'Run query' });
+    const runButton = screen.getByRole('button', { name: 'Run queries' });
     expect(runButton).toBeInTheDocument();
     fireEvent.click(runButton);
     expect(onRunQuery).toBeCalledTimes(1);

--- a/src/sql/QueryEditor/QueryEditorHeader.tsx
+++ b/src/sql/QueryEditor/QueryEditorHeader.tsx
@@ -52,7 +52,7 @@ export function QueryEditorHeader<
           icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
           disabled={data?.state === LoadingState.Loading || !enableRunButton}
         >
-          Run query
+          Run queries
         </Button>
       )}
       {extraHeaderElementRight}


### PR DESCRIPTION
Just a small fix until we wait for the grafana dashboard Run queries button. 

"Run query" is misleading, making it seem like we will only run one query that has the button in the header. Currently grafana doesn't have the functionality to run only one query in a dashboard panel

Namely to use in this PR: https://github.com/grafana/iot-sitewise-datasource/pull/274