### PR TITLE
create github release on new version only

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       new_version: ${{ steps.version_check.outputs.version }}
+      version_changed: ${{ steps.version_check.outputs.changed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -65,6 +66,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: npm-publish
+    if: needs.npm-publish.outputs.version_changed == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes: #83

Runs the `Create GitHub Release` only if the version has changed