### PR TITLE
Chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
Fixes: https://github.com/grafana/oss-plugin-partnerships/issues/933

Adding dependabot
- Made updates weekly (it should be Monday by default so I didn't specify a date explicitly)
- I think the patterns being set to `*` should group it all for the package-ecosystem it's defined under
- There's not a way to group dependency updates across different package-ecosystems yet (https://github.com/dependabot/dependabot-core/issues/8126)

I didn't add the combine-prs action as a part of this PR because this might be good enough for keeping dependabot notifications to a minimum for now? There might still be cases where multiple PRs are opened, e.g. security updates are always opened in a single PR.