### PR TITLE
Chore: Relax grafana/experimental dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@grafana/async-query-data": "0.2.0",
-    "@grafana/experimental": "2.1.2"
+    "@grafana/experimental": "^2.1.2"
   },
   "devDependencies": {
     "@grafana/data": "11.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,7 +1104,7 @@
     eslint-plugin-react-hooks "4.6.0"
     typescript "5.2.2"
 
-"@grafana/experimental@2.1.2":
+"@grafana/experimental@^2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-2.1.2.tgz#bf4d66495bbd0d15e178fcd48e551722aa155355"
   integrity sha512-P25G9nOuY4wdksksbBUtFxZlO5Mjchlbn2YXhExITszsVq+Cdgqdo3qezUi+kdiSDwFiJ/RzR4VMJqgZ0j9TPQ==


### PR DESCRIPTION
The @grafana/aws-sdk is used in grafana/grafana but due to it's dependency on experimental being pinned and not falling into the same semver range as Grafanas own dependency on experimental we end up with multiple copies of grafana/experimental in our grafana bundles.

This PR should prevent this from occurring in the future by relaxing this packages semver range to minor, patch.

