### PR TITLE
Prepare 0.7.1 and fix npm token reference

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -59,7 +59,7 @@ jobs:
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           repo_secrets: |
-            NPM_TOKEN=npm-release.npm_token
+            NPM_TOKEN=npm-release:npm_token
 
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.7.1
+
+- Chore: Use vault to get npm token in [#145](https://github.com/grafana/grafana-aws-sdk-react/pull/145)
+- add zizmor ignore rule in #[144](https://github.com/grafana/grafana-aws-sdk-react/pull/144)
+- Use vault to generate token in [#143](https://github.com/grafana/grafana-aws-sdk-react/pull/143)
+- Cleanup github actions files in [#141](https://github.com/grafana/grafana-aws-sdk-react/pull/141)
+- Bump the all-dependencies group across 1 directory with 29 updates in [#140](https://github.com/grafana/grafana-aws-sdk-react/pull/140)
+
 ## v0.7.0
 
 - Allow hiding assume role inputs in https://github.com/grafana/grafana-aws-sdk-react/pull/126

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -17,6 +17,7 @@
     "gofmt",
     "hmac",
     "grabpl",
-    "spellcheck"
+    "spellcheck",
+    "zizmor"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## v0.7.1

- Chore: Use vault to get npm token in [#145](https://github.com/grafana/grafana-aws-sdk-react/pull/145)
- add zizmor ignore rule in #[144](https://github.com/grafana/grafana-aws-sdk-react/pull/144)
- Use vault to generate token in [#143](https://github.com/grafana/grafana-aws-sdk-react/pull/143)
- Cleanup github actions files in [#141](https://github.com/grafana/grafana-aws-sdk-react/pull/141)
- Bump the all-dependencies group across 1 directory with 29 updates in [#140](https://github.com/grafana/grafana-aws-sdk-react/pull/140)