### PR TITLE
Fix dependabot ignore location for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,6 @@ updates:
           - '@grafana/runtime'
           - '@grafana/schema'
           - '@grafana/ui'
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      time: '12:00'
-    open-pull-requests-limit: 3
-    cooldown:
-      default-days: 7
-      exclude:
-        - 'grafana/*'
-
     # Ignore dependencies that need to be updated manually for compatibility reasons
     ignore:
       # Keep @types/node in sync with the node version in .nvmrc
@@ -47,3 +36,13 @@ updates:
         update-types: ['version-update:semver-major']
       # Keep rxjs in sync with the version used by `@grafana/*` packages
       - dependency-name: rxjs
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '12:00'
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      exclude:
+        - 'grafana/*'


### PR DESCRIPTION
In the previous PR to tweak the dependabot rules, I didn't move the NPM ignore block up along with the rest of the npm configuration so the ignore rules are not being applied for the NPM packages.