### PR TITLE
Add tracking for when auth type is changed

### DIFF
--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -12,6 +12,7 @@ import { AwsAuthType, ConnectionConfigProps } from '../types';
 import { awsAuthProviderOptions } from '../providers';
 import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
+import { trackAwsSdkConfigAuthSelected } from './tracking';
 
 export const DEFAULT_LABEL_WIDTH = 28;
 const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = ['cloudwatch', 'grafana-athena-datasource'];
@@ -85,6 +86,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
               defaultValue={options.jsonData.authType}
               onChange={(option) => {
                 onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
+                trackAwsSdkConfigAuthSelected({ authType: option.value, datasourceType: options.type });
               }}
               menuShouldPortal={true}
             />

--- a/src/components/tracking.ts
+++ b/src/components/tracking.ts
@@ -1,0 +1,6 @@
+import { reportInteraction } from '@grafana/runtime';
+import { AwsAuthType } from '../types';
+
+export const trackAwsSdkConfigAuthSelected = (props: { authType?: AwsAuthType; datasourceType?: string }) => {
+  reportInteraction('aws-sdk-config-auth-selected', props);
+};


### PR DESCRIPTION
We wanted to add tracking to help see how many user are using Grafana Assume Role. (Probably should have gone in before the GA, but oh well)