### PR TITLE
feat: enable Grafana Assume Role UI for grafana-iot-sitewise-datasource

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -18,6 +18,7 @@
     "hmac",
     "grabpl",
     "spellcheck",
-    "zizmor"
+    "zizmor",
+    "sitewise"
   ]
 }

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -14,7 +14,7 @@ import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
 
 export const DEFAULT_LABEL_WIDTH = 28;
-const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = ['cloudwatch', 'grafana-athena-datasource'];
+const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = ['cloudwatch', 'grafana-athena-datasource', 'grafana-iot-sitewise-datasource'];
 const toOption = (value: string) => ({ value, label: value });
 const isAwsAuthType = (value: any): value is AwsAuthType => {
   return typeof value === 'string' && awsAuthProviderOptions.some((opt) => opt.value === value);


### PR DESCRIPTION
What: Added grafana-iot-sitewise-datasource to DS_TYPES_THAT_SUPPORT_TEMP_CREDS.

Why: Brings SiteWise to parity with CloudWatch/Athena for Cloud’s managed temp-creds flow; no effect on OSS.

Safety: Pure UI gating; no backend changes; tested build; screenshots (optional).

Link: Relates to https://github.com/grafana/iot-sitewise-datasource/issues/473