### PR TITLE
Feat: add amazonprometheus to grafana assume role support list

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -18,6 +18,7 @@
     "hmac",
     "grabpl",
     "spellcheck",
+    "amazonprometheus",
     "zizmor"
   ]
 }

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -14,7 +14,11 @@ import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
 
 export const DEFAULT_LABEL_WIDTH = 28;
-const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = ['cloudwatch', 'grafana-athena-datasource'];
+const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = [
+  'cloudwatch',
+  'grafana-athena-datasource',
+  'grafana-amazonprometheus-datasource',
+];
 const toOption = (value: string) => ({ value, label: value });
 const isAwsAuthType = (value: any): value is AwsAuthType => {
   return typeof value === 'string' && awsAuthProviderOptions.some((opt) => opt.value === value);


### PR DESCRIPTION
Enabling front-end support for Grafana Assume Role for the AMP datasource. Backend support is in testing but that testing depends on this.