### PR TITLE
Update npm in publish-npm.yml only when node is setup

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'
-        run: npm publish --access public --scope grafana
+        run: npm publish --access public
 
       - name: Setup .npmrc file for GitHub Packages
         if: steps.version_check.outputs.changed == 'true'


### PR DESCRIPTION
Got a [failure](https://github.com/grafana/grafana-aws-sdk-react/actions/runs/18313846677/job/52148765739) after merging https://github.com/grafana/grafana-aws-sdk-react/pull/303. I think it's because it tries to install npm without node being setup since `actions/setup-node@v5` is only run if there's a version change.