### PR TITLE
Show Grafana Assume Role for DynamoDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.10.3
+
+- Show Grafana Assume Role for the DynamoDB data source in [#467](https://github.com/grafana/grafana-aws-sdk-react/pull/467)
+- chore(deps): update EndBug/version-check action to v3 in [#439](https://github.com/grafana/grafana-aws-sdk-react/pull/439)
+- Set enable scripts to false in .yarnrc.yml in [#464](https://github.com/grafana/grafana-aws-sdk-react/pull/464)
+- chore(deps): update dependency @grafana/ui to v13 in [#462](https://github.com/grafana/grafana-aws-sdk-react/pull/462)
+- chore(deps): update grafana/shared-workflows/ action in [#456](https://github.com/grafana/grafana-aws-sdk-react/pull/456)
+- chore(deps): update actions/setup-node digest to 48b55a0 in [#455](https://github.com/grafana/grafana-aws-sdk-react/pull/455)
+- chore(deps): update dependency rollup-plugin-node-externals to v9 in [#453](https://github.com/grafana/grafana-aws-sdk-react/pull/453)
+- chore(deps): lock file maintenance in [#451](https://github.com/grafana/grafana-aws-sdk-react/pull/451)
+- chore(deps): lock file maintenance in [#450](https://github.com/grafana/grafana-aws-sdk-react/pull/450)
+- chore(deps): update dependency cspell to v10 in [#448](https://github.com/grafana/grafana-aws-sdk-react/pull/448)
+- chore(deps): lock file maintenance in [#447](https://github.com/grafana/grafana-aws-sdk-react/pull/447)
+- Update codeowners in [#446](https://github.com/grafana/grafana-aws-sdk-react/pull/446)
+- chore(deps): update grafana/shared-workflows/ action in [#445](https://github.com/grafana/grafana-aws-sdk-react/pull/445)
+- chore(deps): update grafana/shared-workflows/ action in [#444](https://github.com/grafana/grafana-aws-sdk-react/pull/444)
+- chore(deps): lock file maintenance in [#443](https://github.com/grafana/grafana-aws-sdk-react/pull/443)
+- chore(deps): lock file maintenance in [#442](https://github.com/grafana/grafana-aws-sdk-react/pull/442)
+- chore(deps): update grafana/shared-workflows/ action in [#441](https://github.com/grafana/grafana-aws-sdk-react/pull/441)
+- chore(deps): update actions/create-github-app-token action to v3 in [#438](https://github.com/grafana/grafana-aws-sdk-react/pull/438)
+- chore(deps): update actions/create-github-app-token digest to fee1f7d in [#437](https://github.com/grafana/grafana-aws-sdk-react/pull/437)
+- chore(deps): lock file maintenance in [#434](https://github.com/grafana/grafana-aws-sdk-react/pull/434)
+- chore(deps): update frontend dependencies to v10 in [#433](https://github.com/grafana/grafana-aws-sdk-react/pull/433)
+
 ## v0.10.2
 - Add config save event reporting to ConnectionConfig in [#435](https://github.com/grafana/grafana-aws-sdk-react/pull/435)
 - chore(deps): lock file maintenance in [#422](https://github.com/grafana/grafana-aws-sdk-react/pull/422)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -24,6 +24,7 @@
     "amazonprometheus",
     "zizmor",
     "sitewise",
+    "twinmaker",
     "npmPreapprovedPackages"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Common AWS features for grafana",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -73,6 +73,13 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('ConnectionConfig', () => {
+  const renderWithDataSourceType = (type: string) => {
+    const props = getProps();
+    const options = { ...props.options, type };
+
+    render(<ConnectionConfig {...props} options={options} />);
+  };
+
   afterEach(() => {
     config.awsAllowedAuthProviders = [AwsAuthType.EC2IAMRole, AwsAuthType.Keys, AwsAuthType.Credentials];
     config.featureToggles.awsDatasourcesTempCredentials = false;
@@ -217,30 +224,54 @@ describe('ConnectionConfig', () => {
     const link = screen.getByRole('link', { name: 'Grafana Assume Role' });
     expect(link).toBeInTheDocument();
   });
-  it('should render GrafanaAssumeRole as auth type if the feature flag is enabled and auth providers has GrafanaAssumeRole and the datasource supports temp credentials', async () => {
+  it.each([
+    'cloudwatch',
+    'grafana-amazonprometheus-datasource',
+    'grafana-athena-datasource',
+    'grafana-aurora-datasource',
+    'grafana-dynamodb-datasource',
+    'grafana-iot-sitewise-datasource',
+    'grafana-opensearch-datasource',
+    'grafana-redshift-datasource',
+    'grafana-timestream-datasource',
+    'grafana-x-ray-datasource',
+  ])(
+    'should render GrafanaAssumeRole as an auth type for %s when temp credentials are enabled',
+    async (dataSourceType) => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      renderWithDataSourceType(dataSourceType);
+
+      await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
+      expect(screen.getByText('Grafana Assume Role')).toBeInTheDocument();
+    }
+  );
+
+  it('should not render GrafanaAssumeRole as an auth type for TwinMaker because it does not support temp credentials', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const props = getProps();
-    const overwriteOptions = { ...props.options, type: 'cloudwatch' };
-    render(<ConnectionConfig {...props} options={overwriteOptions} />);
-    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
-    expect(screen.getByText('Credentials file')).toBeInTheDocument();
-    expect(screen.queryByText('Grafana Assume Role')).toBeInTheDocument();
-  });
-  it('should not render GrafanaAssumeRole as auth type if the feature flag is not enabled', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = false;
-    const props = getProps();
-    render(<ConnectionConfig {...props} />);
+    renderWithDataSourceType('grafana-iot-twinmaker-datasource');
+
     await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
     expect(screen.getByText('Credentials file')).toBeInTheDocument();
     expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
   });
-  it('should not render GrafanaAssumeRole if the datasource is not a supported datasource type', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
+
+  it('should not render GrafanaAssumeRole as an auth type if the feature flag is not enabled', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = false;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const props = getProps();
-    const overwriteOptions = { ...props.options, type: 'grafana-dynamodb-datasource' };
-    render(<ConnectionConfig {...props} options={overwriteOptions} />);
+    renderWithDataSourceType('cloudwatch');
+
+    await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
+    expect(screen.getByText('Credentials file')).toBeInTheDocument();
+    expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
+  });
+
+  it('should not render GrafanaAssumeRole as an auth type if it is not an allowed auth provider', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.Credentials];
+    renderWithDataSourceType('cloudwatch');
+
     await selectEvent.openMenu(screen.getByLabelText('Authentication Provider'));
     expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
   });

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -20,6 +20,7 @@ const DS_TYPES_THAT_SUPPORT_TEMP_CREDS = [
   'grafana-amazonprometheus-datasource',
   'grafana-athena-datasource',
   'grafana-aurora-datasource',
+  'grafana-dynamodb-datasource',
   'grafana-iot-sitewise-datasource',
   'grafana-opensearch-datasource',
   'grafana-redshift-datasource',


### PR DESCRIPTION
adds `grafana-dynamodb-datasource` to `DS_TYPES_THAT_SUPPORT_TEMP_CREDS` in `src/components/ConnectionConfig.tsx` so the "Grafana Assume Role" option shows up as an option when configuring the authentication provider for a DynamoDB data source. Also prepares release 0.10.3

<img width="606" height="238" alt="dynamodb authentication provider configuration with grafana assume role as an option" src="https://github.com/user-attachments/assets/e1b9ff42-a6f7-45e1-b734-54a94f766cf2" />
