### PR TITLE
chore: don't pin peerDependencies in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,13 @@
         "rxjs"
       ],
       "enabled": false
+    },
+    {
+      "description": "Don't pin peerDependencies, keep them as ranges and only widen when needed",
+      "matchDepTypes": [
+        "peerDependencies"
+      ],
+      "rangeStrategy": "widen"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The inherited `data-sources/base` Renovate preset applies `rangeStrategy: "pin"` to all dependencies, which would rewrite `peerDependencies` ranges (e.g. `">=0.14.0"`) into a single exact version. Pinning a peer dependency defeats its purpose — consumers should control which compatible version they dedupe to.

This adds a `packageRule` scoped to `peerDependencies` that uses `rangeStrategy: "widen"` instead, so the declared range is preserved and only widened when a new version would otherwise fall outside it.