### PR TITLE
UI toggle for per-datasource grafanaExternalId (Grafana Assume Role)

### DIFF
--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -389,31 +389,6 @@ describe('ConnectionConfig', () => {
     expect(screen.queryByText(/unique to this data source/i)).not.toBeInTheDocument();
   });
 
-  it('should describe per-datasource external ID as unique in IAM instructions', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const perDsId = 'stackABC-dsUid1';
-    const props = getProps({
-      options: {
-        id: 21,
-        uid: 'dsUid1',
-        type: 'cloudwatch',
-        jsonData: {
-          authType: AwsAuthType.GrafanaAssumeRole,
-          usePerDatasourceExternalId: true,
-          grafanaExternalId: perDsId,
-        },
-      },
-      externalId: 'stack-should-not-win',
-    });
-    render(<ConnectionConfig {...props} />);
-    await waitFor(() => expect(screen.getByDisplayValue(perDsId)).toBeInTheDocument());
-    await userEvent.click(screen.getByText(/How to create an IAM role for grafana to assume/i));
-    expect(screen.getAllByText(/unique to this data source/i).length).toBeGreaterThan(0);
-    expect(screen.queryByText(/shared stack external ID — legacy/i)).not.toBeInTheDocument();
-  });
-
   it('should not auto-migrate legacy GrafanaAssumeRole datasources on load', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -732,6 +732,100 @@ describe('ConnectionConfig', () => {
         })
       );
     });
+
+    it('shows stack external ID when toggle is off even if externalId prop is the resolved per-DS ID', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      // CloudWatch passes /external-id (resolved) as props.externalId — often the per-DS value.
+      const props = getProps({
+        externalId: 'stackABC-dsUid1',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: {
+            authType: AwsAuthType.GrafanaAssumeRole,
+            usePerDatasourceExternalId: false,
+            grafanaExternalId: 'stackABC-dsUid1',
+          },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
+      expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
+      expect(screen.getByText(/Shared stack external ID \(legacy\)/i)).toBeInTheDocument();
+    });
+
+    it('toggling off updates the displayed ID to the stack value', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+
+      const Stateful = () => {
+        const [options, setOptions] = React.useState(
+          getProps({
+            options: {
+              id: 21,
+              uid: 'dsUid1',
+              type: 'cloudwatch',
+              jsonData: {
+                authType: AwsAuthType.GrafanaAssumeRole,
+                usePerDatasourceExternalId: true,
+                grafanaExternalId: 'stackABC-dsUid1',
+              },
+            },
+          }).options
+        );
+        return (
+          <ConnectionConfig
+            {...getProps()}
+            options={options}
+            // Resolved /external-id while mode was on
+            externalId="stackABC-dsUid1"
+            onOptionsChange={setOptions}
+          />
+        );
+      };
+
+      render(<Stateful />);
+      await waitFor(() => expect(screen.getByDisplayValue('stackABC-dsUid1')).toBeInTheDocument());
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
+      expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
+    });
+
+    it('clears the warning when the toggle is returned to its original value', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const baseOptions = {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: {
+          authType: AwsAuthType.GrafanaAssumeRole,
+          usePerDatasourceExternalId: true,
+          grafanaExternalId: 'stackABC-dsUid1',
+        },
+      };
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: baseOptions,
+      });
+      const { rerender } = render(<ConnectionConfig {...props} />);
+
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
+
+      const afterDisable = onOptionsChange.mock.calls.at(-1)?.[0];
+      rerender(<ConnectionConfig {...props} options={afterDisable} />);
+
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
+    });
   });
 
   it('should show url fields if http proxy type is url', async () => {

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -262,6 +262,30 @@ describe('ConnectionConfig', () => {
     );
   });
 
+  it('should not mint a per-datasource external ID when datasource uid is missing', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: '',
+        type: 'cloudwatch',
+        jsonData: { authType: undefined },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(onOptionsChange).toHaveBeenCalled());
+    expect(onOptionsChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
+      })
+    );
+  });
+
   it('should mint per-datasource external ID after stack external ID loads asynchronously', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -639,7 +639,10 @@ describe('ConnectionConfig', () => {
       await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
       expect(onOptionsChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          jsonData: expect.objectContaining({ grafanaExternalId: 'stackABC-dsUid1' }),
+          jsonData: expect.objectContaining({
+            usePerDatasourceExternalId: true,
+            grafanaExternalId: 'stackABC-dsUid1',
+          }),
         })
       );
       expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
@@ -659,6 +662,7 @@ describe('ConnectionConfig', () => {
           type: 'cloudwatch',
           jsonData: {
             authType: AwsAuthType.GrafanaAssumeRole,
+            usePerDatasourceExternalId: false,
             grafanaExternalId: '',
           },
         },
@@ -667,12 +671,15 @@ describe('ConnectionConfig', () => {
       await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
       expect(onOptionsChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          jsonData: expect.objectContaining({ grafanaExternalId: 'stackABC-dsUid1' }),
+          jsonData: expect.objectContaining({
+            usePerDatasourceExternalId: true,
+            grafanaExternalId: 'stackABC-dsUid1',
+          }),
         })
       );
     });
 
-    it('disabling toggle clears grafanaExternalId to empty string', async () => {
+    it('disabling toggle sets usePerDatasourceExternalId false and clears grafanaExternalId', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
       config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
@@ -686,6 +693,7 @@ describe('ConnectionConfig', () => {
           type: 'cloudwatch',
           jsonData: {
             authType: AwsAuthType.GrafanaAssumeRole,
+            usePerDatasourceExternalId: true,
             grafanaExternalId: 'stackABC-dsUid1',
           },
         },
@@ -694,7 +702,10 @@ describe('ConnectionConfig', () => {
       await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
       expect(onOptionsChange).toHaveBeenCalledWith(
         expect.objectContaining({
-          jsonData: expect.objectContaining({ grafanaExternalId: '' }),
+          jsonData: expect.objectContaining({
+            usePerDatasourceExternalId: false,
+            grafanaExternalId: '',
+          }),
         })
       );
     });

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {
   AwsAuthDataSourceJsonData,
   AwsAuthDataSourceSecureJsonData,
@@ -63,6 +64,7 @@ jest.mock('@grafana/runtime', () => ({
     awsAllowedAuthProviders: [AwsAuthType.EC2IAMRole, AwsAuthType.Keys, AwsAuthType.Credentials],
     featureToggles: {
       awsDatasourcesTempCredentials: false,
+      awsAssumeRolePerDatasourceExternalId: false,
     },
     namespace: '',
   },
@@ -83,6 +85,7 @@ describe('ConnectionConfig', () => {
   afterEach(() => {
     config.awsAllowedAuthProviders = [AwsAuthType.EC2IAMRole, AwsAuthType.Keys, AwsAuthType.Credentials];
     config.featureToggles.awsDatasourcesTempCredentials = false;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
     //@ts-ignore
     config.awsAssumeRoleEnabled = undefined;
   });
@@ -216,6 +219,7 @@ describe('ConnectionConfig', () => {
 
   it('should mint a per-datasource external ID when defaulting to GrafanaAssumeRole', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
     const onOptionsChange = jest.fn();
     const props = getProps({
@@ -234,8 +238,71 @@ describe('ConnectionConfig', () => {
     expect(update.jsonData.grafanaExternalId).toBe('stackABC-dsUid1');
   });
 
+  it('should not mint a per-datasource external ID when the feature toggle is off', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: undefined },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(onOptionsChange).toHaveBeenCalled());
+    expect(onOptionsChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
+      })
+    );
+  });
+
+  it('should mint per-datasource external ID after stack external ID loads asynchronously', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+
+    const Stateful = () => {
+      const [externalId, setExternalId] = React.useState('');
+      const [options, setOptions] = React.useState(
+        getProps({
+          options: {
+            id: 21,
+            uid: 'dsUid1',
+            type: 'cloudwatch',
+            jsonData: { authType: undefined },
+          },
+        }).options
+      );
+
+      React.useEffect(() => {
+        const t = window.setTimeout(() => setExternalId('stackABC'), 10);
+        return () => window.clearTimeout(t);
+      }, []);
+
+      return (
+        <ConnectionConfig
+          {...getProps()}
+          options={options}
+          externalId={externalId}
+          onOptionsChange={(next) => setOptions(next)}
+        />
+      );
+    };
+
+    render(<Stateful />);
+    await waitFor(() => expect(screen.getByDisplayValue('stackABC-dsUid1')).toBeInTheDocument());
+    expect(screen.getByText(/Unique to this data source/i)).toBeInTheDocument();
+  });
+
   it('should show per-datasource external ID when grafanaExternalId is set', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
     const perDsId = 'stackABC-dsUid1';
     const props = getProps({
@@ -257,6 +324,7 @@ describe('ConnectionConfig', () => {
 
   it('should fall back to stack external ID for legacy GrafanaAssumeRole datasources', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
     const props = getProps({
       options: {
@@ -270,10 +338,38 @@ describe('ConnectionConfig', () => {
     render(<ConnectionConfig {...props} />);
     await waitFor(() => expect(screen.getByDisplayValue('stack-external-id')).toBeInTheDocument());
     expect(screen.getByText(/Shared stack external ID \(legacy\)/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByText(/How to create an IAM role for grafana to assume/i));
+    expect(screen.getByText(/shared stack external ID — legacy/i)).toBeInTheDocument();
+    expect(screen.queryByText(/unique to this data source/i)).not.toBeInTheDocument();
+  });
+
+  it('should describe per-datasource external ID as unique in IAM instructions', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const perDsId = 'stackABC-dsUid1';
+    const props = getProps({
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: {
+          authType: AwsAuthType.GrafanaAssumeRole,
+          grafanaExternalId: perDsId,
+        },
+      },
+      externalId: 'stack-should-not-win',
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByDisplayValue(perDsId)).toBeInTheDocument());
+    await userEvent.click(screen.getByText(/How to create an IAM role for grafana to assume/i));
+    expect(screen.getAllByText(/unique to this data source/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/shared stack external ID — legacy/i)).not.toBeInTheDocument();
   });
 
   it('should not auto-migrate legacy GrafanaAssumeRole datasources on load', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
     const onOptionsChange = jest.fn();
     const props = getProps({
@@ -297,6 +393,7 @@ describe('ConnectionConfig', () => {
 
   it('should warn when switching to GrafanaAssumeRole mints a new external ID', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
     const onOptionsChange = jest.fn();
     const props = getProps({
@@ -326,8 +423,37 @@ describe('ConnectionConfig', () => {
     );
   });
 
+  it('should not warn when switching to GrafanaAssumeRole while the feature toggle is off', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
+    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: AwsAuthType.Keys },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
+    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
+      container: document.body,
+    });
+    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
+    expect(onOptionsChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
+      })
+    );
+  });
+
   it('should not warn when GrafanaAssumeRole already has a per-datasource external ID', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
     const onOptionsChange = jest.fn();
     const props = getProps({

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -450,7 +450,7 @@ describe('ConnectionConfig', () => {
         id: 21,
         uid: 'dsUid1',
         type: 'cloudwatch',
-        jsonData: { authType: AwsAuthType.Keys },
+        jsonData: { authType: AwsAuthType.Keys, assumeRoleArn: 'arn:aws:iam::123:role/test' },
       },
     });
     render(<ConnectionConfig {...props} />);
@@ -468,6 +468,29 @@ describe('ConnectionConfig', () => {
         }),
       })
     );
+  });
+
+  it('should not warn when switching to GrafanaAssumeRole before Assume Role ARN is set', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: AwsAuthType.Keys },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
+    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
+      container: document.body,
+    });
+    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
   });
 
   it('should not warn when switching to GrafanaAssumeRole while the feature toggle is off', async () => {
@@ -655,7 +678,10 @@ describe('ConnectionConfig', () => {
           id: 21,
           uid: 'dsUid1',
           type: 'cloudwatch',
-          jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+          jsonData: {
+            authType: AwsAuthType.GrafanaAssumeRole,
+            assumeRoleArn: 'arn:aws:iam::123:role/test',
+          },
         },
       });
       render(<ConnectionConfig {...props} />);
@@ -669,6 +695,27 @@ describe('ConnectionConfig', () => {
         })
       );
       expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
+    });
+
+    it('does not warn when toggling before Assume Role ARN is set', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: {
+          // Connections create-then-configure already has an id
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
     });
 
     it('re-enabling toggle after a persisted disable reuses dormant per-datasource external ID', async () => {
@@ -806,6 +853,7 @@ describe('ConnectionConfig', () => {
         type: 'cloudwatch',
         jsonData: {
           authType: AwsAuthType.GrafanaAssumeRole,
+          assumeRoleArn: 'arn:aws:iam::123:role/test',
           usePerDatasourceExternalId: true,
           grafanaExternalId: 'stackABC-dsUid1',
         },

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -324,7 +324,7 @@ describe('ConnectionConfig', () => {
     expect(screen.getByText(/Unique to this data source/i)).toBeInTheDocument();
   });
 
-  it('should show per-datasource external ID when grafanaExternalId is set', async () => {
+  it('should show per-datasource external ID when mode is enabled', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
@@ -336,6 +336,7 @@ describe('ConnectionConfig', () => {
         type: 'cloudwatch',
         jsonData: {
           authType: AwsAuthType.GrafanaAssumeRole,
+          usePerDatasourceExternalId: true,
           grafanaExternalId: perDsId,
         },
       },
@@ -344,6 +345,27 @@ describe('ConnectionConfig', () => {
     render(<ConnectionConfig {...props} />);
     await waitFor(() => expect(screen.getByDisplayValue(perDsId)).toBeInTheDocument());
     expect(screen.queryByDisplayValue('stack-should-not-win')).not.toBeInTheDocument();
+  });
+
+  it('should show stack external ID when bool unset even if grafanaExternalId is stored (legacy)', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const props = getProps({
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: {
+          authType: AwsAuthType.GrafanaAssumeRole,
+          grafanaExternalId: 'stackABC-dsUid1',
+        },
+      },
+      externalId: 'stack-external-id',
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByDisplayValue('stack-external-id')).toBeInTheDocument());
+    expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
   });
 
   it('should fall back to stack external ID for legacy GrafanaAssumeRole datasources', async () => {
@@ -379,6 +401,7 @@ describe('ConnectionConfig', () => {
         type: 'cloudwatch',
         jsonData: {
           authType: AwsAuthType.GrafanaAssumeRole,
+          usePerDatasourceExternalId: true,
           grafanaExternalId: perDsId,
         },
       },

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -563,6 +563,116 @@ describe('ConnectionConfig', () => {
     expect(screen.queryByText('Grafana Assume Role')).not.toBeInTheDocument();
   });
 
+  describe('per-datasource toggle', () => {
+    it('shows per-datasource toggle when FT on and GrafanaAssumeRole selected', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const props = getProps({
+        externalId: 'stackABC',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: { authType: AwsAuthType.GrafanaAssumeRole, grafanaExternalId: 'stackABC-dsUid1' },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await waitFor(() => expect(screen.getByTestId('per-ds-external-id-toggle')).toBeInTheDocument());
+    });
+
+    it('does not show per-datasource toggle when FT is off', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const props = getProps({
+        externalId: 'stackABC',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
+      expect(screen.queryByTestId('per-ds-external-id-toggle')).not.toBeInTheDocument();
+    });
+
+    it('legacy GAR starts with toggle off and stays on stack until enabled', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await waitFor(() => expect(screen.getByTestId('per-ds-external-id-toggle')).toBeInTheDocument());
+      expect(screen.getByTestId('per-ds-external-id-toggle')).not.toBeChecked();
+      expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument();
+    });
+
+    it('enabling toggle mints per-datasource external ID', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({ grafanaExternalId: 'stackABC-dsUid1' }),
+        })
+      );
+      expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
+    });
+
+    it('disabling toggle clears grafanaExternalId to empty string', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: {
+            authType: AwsAuthType.GrafanaAssumeRole,
+            grafanaExternalId: 'stackABC-dsUid1',
+          },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({ grafanaExternalId: '' }),
+        })
+      );
+    });
+  });
+
   it('should show url fields if http proxy type is url', async () => {
     // @ts-ignore ignore setting type error
     config.awsPerDatasourceHTTPProxyEnabled = true;

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -780,13 +780,12 @@ describe('ConnectionConfig', () => {
       );
     });
 
-    it('shows stack external ID when toggle is off even if externalId prop is the resolved per-DS ID', async () => {
+    it('shows stack external ID when toggle is off', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
       config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-      // CloudWatch passes /external-id (resolved) as props.externalId — often the per-DS value.
       const props = getProps({
-        externalId: 'stackABC-dsUid1',
+        externalId: 'stackABC',
         options: {
           id: 21,
           uid: 'dsUid1',
@@ -825,13 +824,7 @@ describe('ConnectionConfig', () => {
           }).options
         );
         return (
-          <ConnectionConfig
-            {...getProps()}
-            options={options}
-            // Resolved /external-id while mode was on
-            externalId="stackABC-dsUid1"
-            onOptionsChange={setOptions}
-          />
+          <ConnectionConfig {...getProps()} options={options} externalId="stackABC" onOptionsChange={setOptions} />
         );
       };
 

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -438,7 +438,7 @@ describe('ConnectionConfig', () => {
     );
   });
 
-  it('should warn when switching to GrafanaAssumeRole mints a new external ID', async () => {
+  it('should mint a per-DS external ID when switching to GrafanaAssumeRole without warning', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
@@ -458,8 +458,7 @@ describe('ConnectionConfig', () => {
     await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
       container: document.body,
     });
-    expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
-    expect(screen.getByText(/External ID will change on save/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
     expect(onOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({
         jsonData: expect.objectContaining({
@@ -470,30 +469,7 @@ describe('ConnectionConfig', () => {
     );
   });
 
-  it('should not warn when switching to GrafanaAssumeRole before Assume Role ARN is set', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
-    const onOptionsChange = jest.fn();
-    const props = getProps({
-      onOptionsChange,
-      externalId: 'stackABC',
-      options: {
-        id: 21,
-        uid: 'dsUid1',
-        type: 'cloudwatch',
-        jsonData: { authType: AwsAuthType.Keys },
-      },
-    });
-    render(<ConnectionConfig {...props} />);
-    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
-    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
-      container: document.body,
-    });
-    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
-  });
-
-  it('should not warn when switching to GrafanaAssumeRole while the feature toggle is off', async () => {
+  it('should not mint when switching to GrafanaAssumeRole while the feature toggle is off', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
     config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
@@ -513,7 +489,6 @@ describe('ConnectionConfig', () => {
     await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
       container: document.body,
     });
-    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
     expect(onOptionsChange).not.toHaveBeenCalledWith(
       expect.objectContaining({
         jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
@@ -521,31 +496,6 @@ describe('ConnectionConfig', () => {
     );
   });
 
-  it('should not warn when GrafanaAssumeRole already has a per-datasource external ID', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
-    const onOptionsChange = jest.fn();
-    const props = getProps({
-      onOptionsChange,
-      externalId: 'stackABC',
-      options: {
-        id: 21,
-        uid: 'dsUid1',
-        type: 'cloudwatch',
-        jsonData: {
-          authType: AwsAuthType.Keys,
-          grafanaExternalId: 'stackABC-dsUid1',
-        },
-      },
-    });
-    render(<ConnectionConfig {...props} />);
-    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
-    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
-      container: document.body,
-    });
-    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
-  });
   it('should render "Learn more about Grafana Assume Role" link when GrafanaAssumeRole is selected', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -648,7 +648,7 @@ describe('ConnectionConfig', () => {
       expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
     });
 
-    it('re-enabling toggle after a persisted disable mints per-datasource external ID', async () => {
+    it('re-enabling toggle after a persisted disable reuses dormant per-datasource external ID', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
       config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
@@ -663,7 +663,7 @@ describe('ConnectionConfig', () => {
           jsonData: {
             authType: AwsAuthType.GrafanaAssumeRole,
             usePerDatasourceExternalId: false,
-            grafanaExternalId: '',
+            grafanaExternalId: 'stackABC-dsUid1',
           },
         },
       });
@@ -679,7 +679,7 @@ describe('ConnectionConfig', () => {
       );
     });
 
-    it('disabling toggle sets usePerDatasourceExternalId false and clears grafanaExternalId', async () => {
+    it('disabling toggle sets usePerDatasourceExternalId false and keeps grafanaExternalId', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
       config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
@@ -704,7 +704,7 @@ describe('ConnectionConfig', () => {
         expect.objectContaining({
           jsonData: expect.objectContaining({
             usePerDatasourceExternalId: false,
-            grafanaExternalId: '',
+            grafanaExternalId: 'stackABC-dsUid1',
           }),
         })
       );

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -408,6 +408,49 @@ describe('ConnectionConfig', () => {
     );
   });
 
+  it('should not set usePerDatasourceExternalId when switching to GAR with FT off', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
+    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: AwsAuthType.Keys },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
+    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
+      container: document.body,
+    });
+    expect(onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          authType: AwsAuthType.GrafanaAssumeRole,
+        }),
+      })
+    );
+    expect(onOptionsChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          usePerDatasourceExternalId: true,
+        }),
+      })
+    );
+    expect(onOptionsChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          grafanaExternalId: expect.anything(),
+        }),
+      })
+    );
+  });
+
   it('should render "Learn more about Grafana Assume Role" link when GrafanaAssumeRole is selected', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -645,6 +645,33 @@ describe('ConnectionConfig', () => {
       expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
     });
 
+    it('re-enabling toggle after a persisted disable mints per-datasource external ID', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: {
+          id: 21,
+          uid: 'dsUid1',
+          type: 'cloudwatch',
+          jsonData: {
+            authType: AwsAuthType.GrafanaAssumeRole,
+            grafanaExternalId: '',
+          },
+        },
+      });
+      render(<ConnectionConfig {...props} />);
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({ grafanaExternalId: 'stackABC-dsUid1' }),
+        })
+      );
+    });
+
     it('disabling toggle clears grafanaExternalId to empty string', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -347,106 +347,40 @@ describe('ConnectionConfig', () => {
     expect(screen.queryByDisplayValue('stack-should-not-win')).not.toBeInTheDocument();
   });
 
-  it('should show stack external ID when bool unset even if grafanaExternalId is stored (legacy)', async () => {
+  it('should leave legacy GrafanaAssumeRole on stack mode without auto-migrating', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
     config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const onOptionsChange = jest.fn();
     const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
       options: {
         id: 21,
         uid: 'dsUid1',
         type: 'cloudwatch',
+        // Unset bool = stack mode even if a dormant per-DS ID is stored.
         jsonData: {
           authType: AwsAuthType.GrafanaAssumeRole,
           grafanaExternalId: 'stackABC-dsUid1',
         },
       },
-      externalId: 'stack-external-id',
-    });
-    render(<ConnectionConfig {...props} />);
-    await waitFor(() => expect(screen.getByDisplayValue('stack-external-id')).toBeInTheDocument());
-    expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
-  });
-
-  it('should fall back to stack external ID for legacy GrafanaAssumeRole datasources', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const props = getProps({
-      options: {
-        id: 21,
-        uid: 'abc123',
-        type: 'cloudwatch',
-        jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
-      },
-      externalId: 'stack-external-id',
-    });
-    render(<ConnectionConfig {...props} />);
-    await waitFor(() => expect(screen.getByDisplayValue('stack-external-id')).toBeInTheDocument());
-    expect(screen.getByText(/Shared stack external ID \(legacy\)/i)).toBeInTheDocument();
-    await userEvent.click(screen.getByText(/How to create an IAM role for grafana to assume/i));
-    expect(screen.getByText(/shared stack external ID — legacy/i)).toBeInTheDocument();
-    expect(screen.queryByText(/unique to this data source/i)).not.toBeInTheDocument();
-  });
-
-  it('should not auto-migrate legacy GrafanaAssumeRole datasources on load', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-    const onOptionsChange = jest.fn();
-    const props = getProps({
-      onOptionsChange,
-      externalId: 'stackABC',
-      options: {
-        id: 21,
-        uid: 'dsUid1',
-        type: 'cloudwatch',
-        jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
-      },
     });
     render(<ConnectionConfig {...props} />);
     await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
+    expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('per-ds-external-id-toggle')).not.toBeChecked();
+    expect(screen.getByText(/Shared stack external ID \(legacy\)/i)).toBeInTheDocument();
     expect(onOptionsChange).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
+        jsonData: expect.objectContaining({ usePerDatasourceExternalId: true }),
       })
     );
   });
 
-  it('should mint a per-DS external ID when switching to GrafanaAssumeRole without warning', async () => {
+  it('should mint a per-DS external ID when switching to GrafanaAssumeRole', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
-    const onOptionsChange = jest.fn();
-    const props = getProps({
-      onOptionsChange,
-      externalId: 'stackABC',
-      options: {
-        id: 21,
-        uid: 'dsUid1',
-        type: 'cloudwatch',
-        jsonData: { authType: AwsAuthType.Keys, assumeRoleArn: 'arn:aws:iam::123:role/test' },
-      },
-    });
-    render(<ConnectionConfig {...props} />);
-    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
-    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
-      container: document.body,
-    });
-    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
-    expect(onOptionsChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        jsonData: expect.objectContaining({
-          authType: AwsAuthType.GrafanaAssumeRole,
-          grafanaExternalId: 'stackABC-dsUid1',
-        }),
-      })
-    );
-  });
-
-  it('should not mint when switching to GrafanaAssumeRole while the feature toggle is off', async () => {
-    config.featureToggles.awsDatasourcesTempCredentials = true;
-    config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
     config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
     const onOptionsChange = jest.fn();
     const props = getProps({
@@ -464,9 +398,12 @@ describe('ConnectionConfig', () => {
     await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
       container: document.body,
     });
-    expect(onOptionsChange).not.toHaveBeenCalledWith(
+    expect(onOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({
-        jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
+        jsonData: expect.objectContaining({
+          authType: AwsAuthType.GrafanaAssumeRole,
+          grafanaExternalId: 'stackABC-dsUid1',
+        }),
       })
     );
   });
@@ -535,23 +472,6 @@ describe('ConnectionConfig', () => {
   });
 
   describe('per-datasource toggle', () => {
-    it('shows per-datasource toggle when FT on and GrafanaAssumeRole selected', async () => {
-      config.featureToggles.awsDatasourcesTempCredentials = true;
-      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-      const props = getProps({
-        externalId: 'stackABC',
-        options: {
-          id: 21,
-          uid: 'dsUid1',
-          type: 'cloudwatch',
-          jsonData: { authType: AwsAuthType.GrafanaAssumeRole, grafanaExternalId: 'stackABC-dsUid1' },
-        },
-      });
-      render(<ConnectionConfig {...props} />);
-      await waitFor(() => expect(screen.getByTestId('per-ds-external-id-toggle')).toBeInTheDocument());
-    });
-
     it('does not show per-datasource toggle when FT is off', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
@@ -570,28 +490,7 @@ describe('ConnectionConfig', () => {
       expect(screen.queryByTestId('per-ds-external-id-toggle')).not.toBeInTheDocument();
     });
 
-    it('legacy GAR starts with toggle off and stays on stack until enabled', async () => {
-      config.featureToggles.awsDatasourcesTempCredentials = true;
-      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-      const onOptionsChange = jest.fn();
-      const props = getProps({
-        onOptionsChange,
-        externalId: 'stackABC',
-        options: {
-          id: 21,
-          uid: 'dsUid1',
-          type: 'cloudwatch',
-          jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
-        },
-      });
-      render(<ConnectionConfig {...props} />);
-      await waitFor(() => expect(screen.getByTestId('per-ds-external-id-toggle')).toBeInTheDocument());
-      expect(screen.getByTestId('per-ds-external-id-toggle')).not.toBeChecked();
-      expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument();
-    });
-
-    it('enabling toggle mints per-datasource external ID', async () => {
+    it('enabling toggle mints per-datasource external ID and warns when ARN is set', async () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
       config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
@@ -626,12 +525,9 @@ describe('ConnectionConfig', () => {
       config.featureToggles.awsDatasourcesTempCredentials = true;
       config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
       config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-      const onOptionsChange = jest.fn();
       const props = getProps({
-        onOptionsChange,
         externalId: 'stackABC',
         options: {
-          // Connections create-then-configure already has an id
           id: 21,
           uid: 'dsUid1',
           type: 'cloudwatch',
@@ -663,6 +559,8 @@ describe('ConnectionConfig', () => {
         },
       });
       render(<ConnectionConfig {...props} />);
+      await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
+      expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
       await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
       expect(onOptionsChange).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -703,61 +601,6 @@ describe('ConnectionConfig', () => {
           }),
         })
       );
-    });
-
-    it('shows stack external ID when toggle is off', async () => {
-      config.featureToggles.awsDatasourcesTempCredentials = true;
-      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-      const props = getProps({
-        externalId: 'stackABC',
-        options: {
-          id: 21,
-          uid: 'dsUid1',
-          type: 'cloudwatch',
-          jsonData: {
-            authType: AwsAuthType.GrafanaAssumeRole,
-            usePerDatasourceExternalId: false,
-            grafanaExternalId: 'stackABC-dsUid1',
-          },
-        },
-      });
-      render(<ConnectionConfig {...props} />);
-      await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
-      expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
-      expect(screen.getByText(/Shared stack external ID \(legacy\)/i)).toBeInTheDocument();
-    });
-
-    it('toggling off updates the displayed ID to the stack value', async () => {
-      config.featureToggles.awsDatasourcesTempCredentials = true;
-      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
-      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
-
-      const Stateful = () => {
-        const [options, setOptions] = React.useState(
-          getProps({
-            options: {
-              id: 21,
-              uid: 'dsUid1',
-              type: 'cloudwatch',
-              jsonData: {
-                authType: AwsAuthType.GrafanaAssumeRole,
-                usePerDatasourceExternalId: true,
-                grafanaExternalId: 'stackABC-dsUid1',
-              },
-            },
-          }).options
-        );
-        return (
-          <ConnectionConfig {...getProps()} options={options} externalId="stackABC" onOptionsChange={setOptions} />
-        );
-      };
-
-      render(<Stateful />);
-      await waitFor(() => expect(screen.getByDisplayValue('stackABC-dsUid1')).toBeInTheDocument());
-      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
-      await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
-      expect(screen.queryByDisplayValue('stackABC-dsUid1')).not.toBeInTheDocument();
     });
 
     it('clears the warning when the toggle is returned to its original value', async () => {

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -206,12 +206,149 @@ describe('ConnectionConfig', () => {
     await waitFor(() => expect(screen.getByTestId('connection-config')).toBeInTheDocument());
     expect(screen.queryByText('Assume Role ARN')).toBeInTheDocument();
   });
-  it('should not render externalId field if GrafanaAssumeRole auth type is selected and the auth type is enabled', async () => {
+  it('should not render editable externalId field if GrafanaAssumeRole auth type is selected', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;
     const props = getProps({ options: { jsonData: { authType: AwsAuthType.GrafanaAssumeRole } } });
     render(<ConnectionConfig {...props} />);
 
-    await waitFor(() => expect(screen.queryByLabelText('External ID')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByPlaceholderText('External ID')).not.toBeInTheDocument());
+  });
+
+  it('should mint a per-datasource external ID when defaulting to GrafanaAssumeRole', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: undefined },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(onOptionsChange).toHaveBeenCalled());
+    const update = onOptionsChange.mock.calls.find((call) => call[0]?.jsonData?.grafanaExternalId)?.[0];
+    expect(update.jsonData.grafanaExternalId).toBe('stackABC-dsUid1');
+  });
+
+  it('should show per-datasource external ID when grafanaExternalId is set', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const perDsId = 'stackABC-dsUid1';
+    const props = getProps({
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: {
+          authType: AwsAuthType.GrafanaAssumeRole,
+          grafanaExternalId: perDsId,
+        },
+      },
+      externalId: 'stack-should-not-win',
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByDisplayValue(perDsId)).toBeInTheDocument());
+    expect(screen.queryByDisplayValue('stack-should-not-win')).not.toBeInTheDocument();
+  });
+
+  it('should fall back to stack external ID for legacy GrafanaAssumeRole datasources', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const props = getProps({
+      options: {
+        id: 21,
+        uid: 'abc123',
+        type: 'cloudwatch',
+        jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+      },
+      externalId: 'stack-external-id',
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByDisplayValue('stack-external-id')).toBeInTheDocument());
+    expect(screen.getByText(/Shared stack external ID \(legacy\)/i)).toBeInTheDocument();
+  });
+
+  it('should not auto-migrate legacy GrafanaAssumeRole datasources on load', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: AwsAuthType.GrafanaAssumeRole },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByDisplayValue('stackABC')).toBeInTheDocument());
+    expect(onOptionsChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({ grafanaExternalId: expect.any(String) }),
+      })
+    );
+  });
+
+  it('should warn when switching to GrafanaAssumeRole mints a new external ID', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: { authType: AwsAuthType.Keys },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
+    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
+      container: document.body,
+    });
+    expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
+    expect(screen.getByText(/External ID will change on save/i)).toBeInTheDocument();
+    expect(onOptionsChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          authType: AwsAuthType.GrafanaAssumeRole,
+          grafanaExternalId: 'stackABC-dsUid1',
+        }),
+      })
+    );
+  });
+
+  it('should not warn when GrafanaAssumeRole already has a per-datasource external ID', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.Keys, AwsAuthType.GrafanaAssumeRole];
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      externalId: 'stackABC',
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        jsonData: {
+          authType: AwsAuthType.Keys,
+          grafanaExternalId: 'stackABC-dsUid1',
+        },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(screen.getByLabelText('Authentication Provider')).toBeInTheDocument());
+    await selectEvent.select(screen.getByLabelText('Authentication Provider'), 'Grafana Assume Role', {
+      container: document.body,
+    });
+    expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
   });
   it('should render "Learn more about Grafana Assume Role" link when GrafanaAssumeRole is selected', async () => {
     config.featureToggles.awsDatasourcesTempCredentials = true;

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -12,7 +12,7 @@ import { standardRegions } from '../regions';
 import { AwsAuthType, ConnectionConfigProps } from '../types';
 import { awsAuthProviderOptions } from '../providers';
 import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
-import { buildGrafanaExternalId, generateDatasourceUid } from './utils/grafanaExternalId';
+import { buildGrafanaExternalId } from './utils/grafanaExternalId';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
 
 export const DEFAULT_LABEL_WIDTH = 28;
@@ -86,16 +86,20 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);
 
   const applyGrafanaExternalId = (nextOptions = options) => {
-    if (!perDsExternalIdFeatureEnabled || nextOptions.jsonData.grafanaExternalId || !stackExternalId) {
+    // Require a real datasource UID — never invent one client-side (collision risk; server mints on save).
+    if (
+      !perDsExternalIdFeatureEnabled ||
+      nextOptions.jsonData.grafanaExternalId ||
+      !stackExternalId ||
+      !nextOptions.uid
+    ) {
       return nextOptions;
     }
-    const uid = nextOptions.uid || generateDatasourceUid();
     return {
       ...nextOptions,
-      uid,
       jsonData: {
         ...nextOptions.jsonData,
-        grafanaExternalId: buildGrafanaExternalId(stackExternalId, uid),
+        grafanaExternalId: buildGrafanaExternalId(stackExternalId, nextOptions.uid),
       },
     };
   };
@@ -130,12 +134,12 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (!perDsExternalIdFeatureEnabled || !pendingPerDsExternalIdRef.current) {
       return;
     }
-    if (!isGrafanaAssumeRole || perDatasourceExternalId || !stackExternalId) {
+    if (!isGrafanaAssumeRole || perDatasourceExternalId || !stackExternalId || !options.uid) {
       return;
     }
     onOptionsChange(applyGrafanaExternalId(options));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- retry minting only when stack ID becomes available
-  }, [stackExternalId, isGrafanaAssumeRole, perDatasourceExternalId, perDsExternalIdFeatureEnabled]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- retry minting when stack ID / uid become available
+  }, [stackExternalId, options.uid, isGrafanaAssumeRole, perDatasourceExternalId, perDsExternalIdFeatureEnabled]);
 
   useEffect(() => {
     if (!loadRegions) {
@@ -176,11 +180,11 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                   });
                   const mintedExternalId = !hadPerDatasourceExternalId && Boolean(next.jsonData.grafanaExternalId);
                   // Warn when leaving another auth type causes a new per-DS external ID to be set.
-                  // Also warn if mint is pending (stack external ID not loaded yet) — save will still set it.
+                  // Also warn if mint is pending (stack ID / uid not ready yet) — save will still set it.
                   setShowExternalIdChangeWarning(
                     Boolean(
                       perDsExternalIdFeatureEnabled &&
-                      (mintedExternalId || (!hadPerDatasourceExternalId && !stackExternalId)) &&
+                      (mintedExternalId || (!hadPerDatasourceExternalId && (!stackExternalId || !options.uid))) &&
                       previousAuthType &&
                       previousAuthType !== AwsAuthType.GrafanaAssumeRole
                     )

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -85,10 +85,8 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   const isGrafanaAssumeRole = options.jsonData.authType === AwsAuthType.GrafanaAssumeRole;
   const perDatasourceExternalId = options.jsonData.grafanaExternalId;
   const stackExternalId = props.externalId;
-  // Toggle on when bool is true, or legacy configs that only have grafanaExternalId set.
-  const usePerDatasourceExternalId =
-    options.jsonData.usePerDatasourceExternalId === true ||
-    (options.jsonData.usePerDatasourceExternalId === undefined && Boolean(perDatasourceExternalId));
+  // Toggle reflects explicit bool only; unset (legacy) is stack mode.
+  const usePerDatasourceExternalId = options.jsonData.usePerDatasourceExternalId === true;
   // Active ID for STS/display: per-DS when mode on, otherwise stack.
   const grafanaExternalIdDisplay = useMemo(() => {
     if (!isGrafanaAssumeRole) {

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -24,7 +24,7 @@ import { standardRegions } from '../regions';
 import { AwsAuthType, ConnectionConfigProps } from '../types';
 import { awsAuthProviderOptions } from '../providers';
 import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
-import { buildGrafanaExternalId } from './utils/grafanaExternalId';
+import { buildGrafanaExternalId, stackExternalIdFromGrafanaExternalId } from './utils/grafanaExternalId';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
 
 export const DEFAULT_LABEL_WIDTH = 28;
@@ -54,6 +54,8 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   // When true, mint grafanaExternalId as soon as stack external ID (props.externalId) is available.
   // Set on auth default / user select of Grafana Assume Role — not for legacy DS that already use stack ID.
   const pendingPerDsExternalIdRef = useRef(false);
+  // Persisted/opened mode — warn only while the toggle differs from this value.
+  const initialUsePerDatasourceExternalIdRef = useRef(props.options.jsonData.usePerDatasourceExternalId === true);
   const {
     loadRegions,
     onOptionsChange,
@@ -84,7 +86,20 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   );
   const isGrafanaAssumeRole = options.jsonData.authType === AwsAuthType.GrafanaAssumeRole;
   const perDatasourceExternalId = options.jsonData.grafanaExternalId;
-  const stackExternalId = props.externalId;
+  // props.externalId is often the resolved /external-id value (per-DS when that mode was active).
+  // When it matches a stored per-DS ID, derive the real stack prefix for stack-mode display/minting.
+  const stackExternalId = useMemo(() => {
+    const derived = stackExternalIdFromGrafanaExternalId(perDatasourceExternalId, options.uid);
+    const propsId = props.externalId;
+    if (
+      derived &&
+      propsId &&
+      (propsId === perDatasourceExternalId || (options.uid && propsId.endsWith(`-${options.uid}`)))
+    ) {
+      return derived;
+    }
+    return propsId || derived;
+  }, [perDatasourceExternalId, options.uid, props.externalId]);
   // Toggle reflects explicit bool only; unset (legacy) is stack mode.
   const usePerDatasourceExternalId = options.jsonData.usePerDatasourceExternalId === true;
   // Active ID for STS/display: per-DS when mode on, otherwise stack.
@@ -131,6 +146,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (!perDsExternalIdFeatureEnabled || !isGrafanaAssumeRole) {
       return;
     }
+    setShowExternalIdChangeWarning(enabled !== initialUsePerDatasourceExternalIdRef.current);
     if (enabled) {
       pendingPerDsExternalIdRef.current = true;
       const next = applyGrafanaExternalId({
@@ -140,12 +156,10 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
           usePerDatasourceExternalId: true,
         },
       });
-      setShowExternalIdChangeWarning(true);
       onOptionsChange(next);
       return;
     }
     pendingPerDsExternalIdRef.current = false;
-    setShowExternalIdChangeWarning(true);
     onOptionsChange({
       ...options,
       jsonData: {
@@ -386,7 +400,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     <li>
                       <p>
                         3. Enter the following external ID (
-                        {perDatasourceExternalId
+                        {usePerDatasourceExternalId
                           ? 'unique to this data source'
                           : perDsExternalIdFeatureEnabled
                             ? 'shared stack external ID — legacy'
@@ -457,7 +471,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     htmlFor="grafanaExternalId"
                     label="External ID"
                     description={
-                      perDatasourceExternalId
+                      usePerDatasourceExternalId
                         ? 'Unique to this data source. Paste this value into your IAM role trust policy.'
                         : perDsExternalIdFeatureEnabled
                           ? 'Shared stack external ID (legacy). New data sources get a unique ID per data source for stronger isolation.'

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
 import { Input, Select, ButtonGroup, ToolbarButton, Text, TextLink, Collapse, Field, Space, Alert } from '@grafana/ui';
 import {
   onUpdateDatasourceJsonDataOptionSelect,
@@ -39,6 +39,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   const [isARNInstructionsOpen, setIsARNInstructionsOpen] = useState(false);
   const [showExternalIdChangeWarning, setShowExternalIdChangeWarning] = useState(false);
   const [regions, setRegions] = useState((props.standardRegions || standardRegions).map(toOption));
+  // When true, mint grafanaExternalId as soon as stack external ID (props.externalId) is available.
+  // Set on auth default / user select of Grafana Assume Role — not for legacy DS that already use stack ID.
+  const pendingPerDsExternalIdRef = useRef(false);
   const {
     loadRegions,
     onOptionsChange,
@@ -55,6 +58,8 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   }
   const tempCredsFeatureEnabled =
     config.featureToggles.awsDatasourcesTempCredentials && DS_TYPES_THAT_SUPPORT_TEMP_CREDS.includes(options.type);
+  // @ts-ignore not yet in published @grafana/data FeatureToggles
+  const perDsExternalIdFeatureEnabled = Boolean(config.featureToggles.awsAssumeRolePerDatasourceExternalId);
   // @ts-ignore ignore feature toggle type error
   const httpProxySettingEnabled = showHttpProxySettings && (config.awsPerDatasourceHTTPProxyEnabled ?? false);
   const awsAssumeRoleEnabled = config.awsAssumeRoleEnabled ?? true;
@@ -81,7 +86,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);
 
   const applyGrafanaExternalId = (nextOptions = options) => {
-    if (nextOptions.jsonData.grafanaExternalId || !stackExternalId) {
+    if (!perDsExternalIdFeatureEnabled || nextOptions.jsonData.grafanaExternalId || !stackExternalId) {
       return nextOptions;
     }
     const uid = nextOptions.uid || generateDatasourceUid();
@@ -111,13 +116,26 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       };
       // New datasources (no authType yet): mint a per-DS ID when defaulting to Grafana Assume Role.
       // Legacy datasources already have authType set and are skipped by !currentProvider.
-      if (defaultAuthType === AwsAuthType.GrafanaAssumeRole) {
+      if (defaultAuthType === AwsAuthType.GrafanaAssumeRole && perDsExternalIdFeatureEnabled) {
+        pendingPerDsExternalIdRef.current = true;
         next = applyGrafanaExternalId(next);
       }
       onOptionsChange(next);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only when auth provider is missing
-  }, [currentProvider, options, onOptionsChange, awsAllowedAuthProviders]);
+  }, [currentProvider, options, onOptionsChange, awsAllowedAuthProviders, perDsExternalIdFeatureEnabled]);
+
+  // props.externalId is often loaded async (e.g. CloudWatch /external-id). Retry minting once it arrives.
+  useEffect(() => {
+    if (!perDsExternalIdFeatureEnabled || !pendingPerDsExternalIdRef.current) {
+      return;
+    }
+    if (!isGrafanaAssumeRole || perDatasourceExternalId || !stackExternalId) {
+      return;
+    }
+    onOptionsChange(applyGrafanaExternalId(options));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- retry minting only when stack ID becomes available
+  }, [stackExternalId, isGrafanaAssumeRole, perDatasourceExternalId, perDsExternalIdFeatureEnabled]);
 
   useEffect(() => {
     if (!loadRegions) {
@@ -146,6 +164,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                 if (option.value === AwsAuthType.GrafanaAssumeRole) {
                   const previousAuthType = options.jsonData.authType;
                   const hadPerDatasourceExternalId = Boolean(options.jsonData.grafanaExternalId);
+                  if (perDsExternalIdFeatureEnabled) {
+                    pendingPerDsExternalIdRef.current = true;
+                  }
                   const next = applyGrafanaExternalId({
                     ...options,
                     jsonData: {
@@ -155,8 +176,14 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                   });
                   const mintedExternalId = !hadPerDatasourceExternalId && Boolean(next.jsonData.grafanaExternalId);
                   // Warn when leaving another auth type causes a new per-DS external ID to be set.
+                  // Also warn if mint is pending (stack external ID not loaded yet) — save will still set it.
                   setShowExternalIdChangeWarning(
-                    Boolean(mintedExternalId && previousAuthType && previousAuthType !== AwsAuthType.GrafanaAssumeRole)
+                    Boolean(
+                      perDsExternalIdFeatureEnabled &&
+                      (mintedExternalId || (!hadPerDatasourceExternalId && !stackExternalId)) &&
+                      previousAuthType &&
+                      previousAuthType !== AwsAuthType.GrafanaAssumeRole
+                    )
                   );
                   onOptionsChange(next);
                   return;
@@ -281,8 +308,13 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     </li>
                     <li>
                       <p>
-                        3. Enter the following external ID (unique to this data source):{' '}
-                        <code>{grafanaExternalIdDisplay || 'External Id is currently unavailable'}</code> and click{' '}
+                        3. Enter the following external ID (
+                        {perDatasourceExternalId
+                          ? 'unique to this data source'
+                          : perDsExternalIdFeatureEnabled
+                            ? 'shared stack external ID — legacy'
+                            : 'shared stack external ID'}
+                        ): <code>{grafanaExternalIdDisplay || 'External Id is currently unavailable'}</code> and click{' '}
                         <code>Next</code>.
                       </p>
                     </li>
@@ -338,7 +370,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     description={
                       perDatasourceExternalId
                         ? 'Unique to this data source. Paste this value into your IAM role trust policy.'
-                        : 'Shared stack external ID (legacy). New data sources get a unique ID per data source for stronger isolation.'
+                        : perDsExternalIdFeatureEnabled
+                          ? 'Shared stack external ID (legacy). New data sources get a unique ID per data source for stronger isolation.'
+                          : 'Shared stack external ID. Paste this value into your IAM role trust policy.'
                     }
                   >
                     <Input id="grafanaExternalId" readOnly value={grafanaExternalIdDisplay} />

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -154,38 +154,27 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   };
 
   const onAuthProviderChange = (option: { value?: AwsAuthType | null }) => {
+    // Warning is only for stack ↔ per-DS toggle while already on Grafana Assume Role.
+    setShowExternalIdChangeWarning(false);
     if (option.value !== AwsAuthType.GrafanaAssumeRole) {
-      setShowExternalIdChangeWarning(false);
       onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
       return;
     }
 
-    const previousAuthType = options.jsonData.authType;
-    const hadPerDatasourceExternalId = Boolean(options.jsonData.grafanaExternalId);
     if (perDsExternalIdFeatureEnabled) {
       pendingPerDsExternalIdRef.current = true;
     }
-    const next = applyGrafanaExternalId({
-      ...options,
-      jsonData: {
-        ...options.jsonData,
-        authType: AwsAuthType.GrafanaAssumeRole,
-        // Keep explicit stack mode; otherwise default to per-DS for this auth switch.
-        usePerDatasourceExternalId: options.jsonData.usePerDatasourceExternalId === false ? false : true,
-      },
-    });
-    const willChangeExternalId =
-      !hadPerDatasourceExternalId && (Boolean(next.jsonData.grafanaExternalId) || !stackExternalId || !options.uid);
-    setShowExternalIdChangeWarning(
-      Boolean(
-        shouldWarnExternalIdChange &&
-        perDsExternalIdFeatureEnabled &&
-        willChangeExternalId &&
-        previousAuthType &&
-        previousAuthType !== AwsAuthType.GrafanaAssumeRole
-      )
+    onOptionsChange(
+      applyGrafanaExternalId({
+        ...options,
+        jsonData: {
+          ...options.jsonData,
+          authType: AwsAuthType.GrafanaAssumeRole,
+          // Keep explicit stack mode; otherwise default to per-DS for this auth switch.
+          usePerDatasourceExternalId: options.jsonData.usePerDatasourceExternalId === false ? false : true,
+        },
+      })
     );
-    onOptionsChange(next);
   };
 
   useEffect(() => {

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -24,7 +24,7 @@ import { standardRegions } from '../regions';
 import { AwsAuthType, ConnectionConfigProps } from '../types';
 import { awsAuthProviderOptions } from '../providers';
 import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
-import { buildGrafanaExternalId, stackExternalIdFromGrafanaExternalId } from './utils/grafanaExternalId';
+import { buildGrafanaExternalId } from './utils/grafanaExternalId';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
 
 export const DEFAULT_LABEL_WIDTH = 28;
@@ -89,20 +89,8 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   // Only warn when an Assume Role ARN is already set — otherwise there is no trust policy
   // to update yet (covers Connections create-then-configure, where id is already assigned).
   const shouldWarnExternalIdChange = Boolean(options.jsonData.assumeRoleArn);
-  // props.externalId is often the resolved /external-id value (per-DS when that mode was active).
-  // When it matches a stored per-DS ID, derive the real stack prefix for stack-mode display/minting.
-  const stackExternalId = useMemo(() => {
-    const derived = stackExternalIdFromGrafanaExternalId(perDatasourceExternalId, options.uid);
-    const propsId = props.externalId;
-    if (
-      derived &&
-      propsId &&
-      (propsId === perDatasourceExternalId || (options.uid && propsId.endsWith(`-${options.uid}`)))
-    ) {
-      return derived;
-    }
-    return propsId || derived;
-  }, [perDatasourceExternalId, options.uid, props.externalId]);
+  // Stack ID from the plugin (e.g. CloudWatch /external-id → AWS_AUTH_EXTERNAL_ID).
+  const stackExternalId = props.externalId;
   // Toggle reflects explicit bool only; unset (legacy) is stack mode.
   const usePerDatasourceExternalId = options.jsonData.usePerDatasourceExternalId === true;
   // Active ID for STS/display: per-DS when mode on, otherwise stack.

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -102,7 +102,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       if (awsAllowedAuthProviders.includes(AwsAuthType.GrafanaAssumeRole)) {
         defaultAuthType = AwsAuthType.GrafanaAssumeRole;
       }
-      let next = {
+      let next: typeof options = {
         ...options,
         jsonData: {
           ...options.jsonData,

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -102,27 +102,33 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (!perDsExternalIdFeatureEnabled || !stackExternalId || !nextOptions.uid) {
       return nextOptions;
     }
-    // Explicit stack mode: key present but empty means the user opted out — do not mint again.
-    if (
-      Object.prototype.hasOwnProperty.call(nextOptions.jsonData, 'grafanaExternalId') &&
-      !nextOptions.jsonData.grafanaExternalId
-    ) {
+    // Explicit stack mode via boolean — do not mint.
+    if (nextOptions.jsonData.usePerDatasourceExternalId === false) {
       return nextOptions;
     }
     if (nextOptions.jsonData.grafanaExternalId) {
-      return nextOptions;
+      return {
+        ...nextOptions,
+        jsonData: {
+          ...nextOptions.jsonData,
+          usePerDatasourceExternalId: true,
+        },
+      };
     }
     return {
       ...nextOptions,
       jsonData: {
         ...nextOptions.jsonData,
+        usePerDatasourceExternalId: true,
         grafanaExternalId: buildGrafanaExternalId(stackExternalId, nextOptions.uid),
       },
     };
   };
 
-  // Checked state of the per-datasource toggle: on only when a (non-empty) per-DS key is set.
-  const usePerDatasourceExternalId = Boolean(perDatasourceExternalId);
+  // Toggle on when bool is true, or legacy configs that only have grafanaExternalId set.
+  const usePerDatasourceExternalId =
+    options.jsonData.usePerDatasourceExternalId === true ||
+    (options.jsonData.usePerDatasourceExternalId === undefined && Boolean(perDatasourceExternalId));
 
   const onPerDatasourceExternalIdToggle = (enabled: boolean) => {
     if (!perDsExternalIdFeatureEnabled || !isGrafanaAssumeRole) {
@@ -130,10 +136,14 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     }
     if (enabled) {
       pendingPerDsExternalIdRef.current = true;
-      // Drop a persisted empty grafanaExternalId key so applyGrafanaExternalId's stack-mode
-      // guard (present-but-empty key) doesn't block minting a fresh per-DS ID.
-      const { grafanaExternalId: _grafanaExternalId, ...restJsonData } = options.jsonData;
-      const next = applyGrafanaExternalId({ ...options, jsonData: restJsonData });
+      const { grafanaExternalId: _cleared, ...restJsonData } = options.jsonData;
+      const next = applyGrafanaExternalId({
+        ...options,
+        jsonData: {
+          ...restJsonData,
+          usePerDatasourceExternalId: true,
+        },
+      });
       setShowExternalIdChangeWarning(true);
       onOptionsChange(next);
       return;
@@ -144,6 +154,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       ...options,
       jsonData: {
         ...options.jsonData,
+        usePerDatasourceExternalId: false,
         grafanaExternalId: '',
       },
     });
@@ -167,7 +178,13 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       // Legacy datasources already have authType set and are skipped by !currentProvider.
       if (defaultAuthType === AwsAuthType.GrafanaAssumeRole && perDsExternalIdFeatureEnabled) {
         pendingPerDsExternalIdRef.current = true;
-        next = applyGrafanaExternalId(next);
+        next = applyGrafanaExternalId({
+          ...next,
+          jsonData: {
+            ...next.jsonData,
+            usePerDatasourceExternalId: true,
+          },
+        });
       }
       onOptionsChange(next);
     }
@@ -179,10 +196,24 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (!perDsExternalIdFeatureEnabled || !pendingPerDsExternalIdRef.current) {
       return;
     }
-    if (!isGrafanaAssumeRole || perDatasourceExternalId || !stackExternalId || !options.uid) {
+    if (
+      !isGrafanaAssumeRole ||
+      options.jsonData.usePerDatasourceExternalId === false ||
+      perDatasourceExternalId ||
+      !stackExternalId ||
+      !options.uid
+    ) {
       return;
     }
-    onOptionsChange(applyGrafanaExternalId(options));
+    onOptionsChange(
+      applyGrafanaExternalId({
+        ...options,
+        jsonData: {
+          ...options.jsonData,
+          usePerDatasourceExternalId: true,
+        },
+      })
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps -- retry minting when stack ID / uid become available
   }, [stackExternalId, options.uid, isGrafanaAssumeRole, perDatasourceExternalId, perDsExternalIdFeatureEnabled]);
 
@@ -221,6 +252,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     jsonData: {
                       ...options.jsonData,
                       authType: AwsAuthType.GrafanaAssumeRole,
+                      usePerDatasourceExternalId: options.jsonData.usePerDatasourceExternalId === false ? false : true,
                     },
                   });
                   const mintedExternalId = !hadPerDatasourceExternalId && Boolean(next.jsonData.grafanaExternalId);

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
-import { Input, Select, ButtonGroup, ToolbarButton, Text, TextLink, Collapse, Field, Space } from '@grafana/ui';
+import { Input, Select, ButtonGroup, ToolbarButton, Text, TextLink, Collapse, Field, Space, Alert } from '@grafana/ui';
 import {
   onUpdateDatasourceJsonDataOptionSelect,
   onUpdateDatasourceResetOption,
@@ -12,6 +12,7 @@ import { standardRegions } from '../regions';
 import { AwsAuthType, ConnectionConfigProps } from '../types';
 import { awsAuthProviderOptions } from '../providers';
 import { assumeRoleInstructionsStyle } from './ConnectionConfig.styles';
+import { buildGrafanaExternalId, generateDatasourceUid } from './utils/grafanaExternalId';
 import { ConfigSection, ConfigSubSection } from '@grafana/plugin-ui';
 
 export const DEFAULT_LABEL_WIDTH = 28;
@@ -36,6 +37,7 @@ const isAwsAuthType = (value: any): value is AwsAuthType => {
 
 export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionConfigProps) => {
   const [isARNInstructionsOpen, setIsARNInstructionsOpen] = useState(false);
+  const [showExternalIdChangeWarning, setShowExternalIdChangeWarning] = useState(false);
   const [regions, setRegions] = useState((props.standardRegions || standardRegions).map(toOption));
   const {
     loadRegions,
@@ -63,15 +65,35 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         .filter(isAwsAuthType),
     [tempCredsFeatureEnabled]
   );
-  const externalId = useMemo(() => {
-    if (tempCredsFeatureEnabled && options.jsonData.authType === AwsAuthType.GrafanaAssumeRole) {
-      if (config.namespace.startsWith('stacks-')) {
-        return config.namespace.substring(config.namespace.indexOf('-') + 1);
-      }
+  const isGrafanaAssumeRole = options.jsonData.authType === AwsAuthType.GrafanaAssumeRole;
+  const perDatasourceExternalId = options.jsonData.grafanaExternalId;
+  const stackExternalId = props.externalId;
+  // Prefer per-DS ID; fall back to stack-level ID (props.externalId) for legacy datasources only.
+  const grafanaExternalIdDisplay = useMemo(() => {
+    if (!isGrafanaAssumeRole) {
+      return undefined;
     }
-    return props.externalId;
-  }, [tempCredsFeatureEnabled, options.jsonData.authType, props.externalId]);
+    if (perDatasourceExternalId) {
+      return perDatasourceExternalId;
+    }
+    return stackExternalId || undefined;
+  }, [isGrafanaAssumeRole, perDatasourceExternalId, stackExternalId]);
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);
+
+  const applyGrafanaExternalId = (nextOptions = options) => {
+    if (nextOptions.jsonData.grafanaExternalId || !stackExternalId) {
+      return nextOptions;
+    }
+    const uid = nextOptions.uid || generateDatasourceUid();
+    return {
+      ...nextOptions,
+      uid,
+      jsonData: {
+        ...nextOptions.jsonData,
+        grafanaExternalId: buildGrafanaExternalId(stackExternalId, uid),
+      },
+    };
+  };
 
   useEffect(() => {
     // Make sure a authType exists in the current model
@@ -80,14 +102,21 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       if (awsAllowedAuthProviders.includes(AwsAuthType.GrafanaAssumeRole)) {
         defaultAuthType = AwsAuthType.GrafanaAssumeRole;
       }
-      onOptionsChange({
+      let next = {
         ...options,
         jsonData: {
           ...options.jsonData,
           authType: defaultAuthType,
         },
-      });
+      };
+      // New datasources (no authType yet): mint a per-DS ID when defaulting to Grafana Assume Role.
+      // Legacy datasources already have authType set and are skipped by !currentProvider.
+      if (defaultAuthType === AwsAuthType.GrafanaAssumeRole) {
+        next = applyGrafanaExternalId(next);
+      }
+      onOptionsChange(next);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only when auth provider is missing
   }, [currentProvider, options, onOptionsChange, awsAllowedAuthProviders]);
 
   useEffect(() => {
@@ -114,11 +143,41 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
               options={awsAuthProviderOptions.filter((opt) => awsAllowedAuthProviders.includes(opt.value!))}
               defaultValue={options.jsonData.authType}
               onChange={(option) => {
+                if (option.value === AwsAuthType.GrafanaAssumeRole) {
+                  const previousAuthType = options.jsonData.authType;
+                  const hadPerDatasourceExternalId = Boolean(options.jsonData.grafanaExternalId);
+                  const next = applyGrafanaExternalId({
+                    ...options,
+                    jsonData: {
+                      ...options.jsonData,
+                      authType: AwsAuthType.GrafanaAssumeRole,
+                    },
+                  });
+                  const mintedExternalId = !hadPerDatasourceExternalId && Boolean(next.jsonData.grafanaExternalId);
+                  // Warn when leaving another auth type causes a new per-DS external ID to be set.
+                  setShowExternalIdChangeWarning(
+                    Boolean(mintedExternalId && previousAuthType && previousAuthType !== AwsAuthType.GrafanaAssumeRole)
+                  );
+                  onOptionsChange(next);
+                  return;
+                }
+                setShowExternalIdChangeWarning(false);
                 onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
               }}
               menuShouldPortal={true}
             />
           </Field>
+          {showExternalIdChangeWarning && (
+            <Alert
+              severity="warning"
+              title="External ID will change on save"
+              data-testid="grafana-external-id-change-warning"
+            >
+              Saving will store a data source-specific external ID. If your IAM role trust policy still uses a different
+              value (for example the shared stack external ID), update the trust policy to match the new external ID or
+              Assume Role will fail.
+            </Alert>
+          )}
           {options.jsonData.authType === 'credentials' && (
             <Field
               label="Credentials Profile Name"
@@ -222,8 +281,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     </li>
                     <li>
                       <p>
-                        3. Enter the following external ID:{' '}
-                        <code>{externalId || 'External Id is currently unavailable'}</code> and click <code>Next</code>.
+                        3. Enter the following external ID (unique to this data source):{' '}
+                        <code>{grafanaExternalIdDisplay || 'External Id is currently unavailable'}</code> and click{' '}
+                        <code>Next</code>.
                       </p>
                     </li>
                     <li>
@@ -271,6 +331,19 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     onChange={onUpdateDatasourceJsonDataOption(props, 'assumeRoleArn')}
                   />
                 </Field>
+                {options.jsonData.authType === AwsAuthType.GrafanaAssumeRole && grafanaExternalIdDisplay && (
+                  <Field
+                    htmlFor="grafanaExternalId"
+                    label="External ID"
+                    description={
+                      perDatasourceExternalId
+                        ? 'Unique to this data source. Paste this value into your IAM role trust policy.'
+                        : 'Shared stack external ID (legacy). New data sources get a unique ID per data source for stronger isolation.'
+                    }
+                  >
+                    <Input id="grafanaExternalId" readOnly value={grafanaExternalIdDisplay} />
+                  </Field>
+                )}
                 {options.jsonData.authType !== AwsAuthType.GrafanaAssumeRole && (
                   <Field
                     htmlFor="externalId"

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -1,5 +1,17 @@
 import React, { FC, useEffect, useMemo, useRef, useState } from 'react';
-import { Input, Select, ButtonGroup, ToolbarButton, Text, TextLink, Collapse, Field, Space, Alert } from '@grafana/ui';
+import {
+  Input,
+  Select,
+  ButtonGroup,
+  ToolbarButton,
+  Text,
+  TextLink,
+  Collapse,
+  Field,
+  Space,
+  Alert,
+  Switch,
+} from '@grafana/ui';
 import {
   onUpdateDatasourceJsonDataOptionSelect,
   onUpdateDatasourceResetOption,
@@ -87,12 +99,17 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
 
   const applyGrafanaExternalId = (nextOptions = options) => {
     // Require a real datasource UID — never invent one client-side (collision risk; server mints on save).
+    if (!perDsExternalIdFeatureEnabled || !stackExternalId || !nextOptions.uid) {
+      return nextOptions;
+    }
+    // Explicit stack mode: key present but empty means the user opted out — do not mint again.
     if (
-      !perDsExternalIdFeatureEnabled ||
-      nextOptions.jsonData.grafanaExternalId ||
-      !stackExternalId ||
-      !nextOptions.uid
+      Object.prototype.hasOwnProperty.call(nextOptions.jsonData, 'grafanaExternalId') &&
+      !nextOptions.jsonData.grafanaExternalId
     ) {
+      return nextOptions;
+    }
+    if (nextOptions.jsonData.grafanaExternalId) {
       return nextOptions;
     }
     return {
@@ -102,6 +119,31 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         grafanaExternalId: buildGrafanaExternalId(stackExternalId, nextOptions.uid),
       },
     };
+  };
+
+  // Checked state of the per-datasource toggle: on only when a (non-empty) per-DS key is set.
+  const usePerDatasourceExternalId = Boolean(perDatasourceExternalId);
+
+  const onPerDatasourceExternalIdToggle = (enabled: boolean) => {
+    if (!perDsExternalIdFeatureEnabled || !isGrafanaAssumeRole) {
+      return;
+    }
+    if (enabled) {
+      pendingPerDsExternalIdRef.current = true;
+      const next = applyGrafanaExternalId(options);
+      setShowExternalIdChangeWarning(true);
+      onOptionsChange(next);
+      return;
+    }
+    pendingPerDsExternalIdRef.current = false;
+    setShowExternalIdChangeWarning(true);
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        grafanaExternalId: '',
+      },
+    });
   };
 
   useEffect(() => {
@@ -204,9 +246,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
               title="External ID will change on save"
               data-testid="grafana-external-id-change-warning"
             >
-              Saving will store a data source-specific external ID. If your IAM role trust policy still uses a different
-              value (for example the shared stack external ID), update the trust policy to match the new external ID or
-              Assume Role will fail.
+              Saving will change the external ID used to assume this role (switching between the data source-specific ID
+              and the shared stack ID). Update your IAM role trust policy to match the new external ID or Assume Role
+              will fail.
             </Alert>
           )}
           {options.jsonData.authType === 'credentials' && (
@@ -367,6 +409,18 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                     onChange={onUpdateDatasourceJsonDataOption(props, 'assumeRoleArn')}
                   />
                 </Field>
+                {perDsExternalIdFeatureEnabled && isGrafanaAssumeRole && (
+                  <Field
+                    label="Per-data-source external ID"
+                    description="When enabled, this data source uses a unique external ID. When disabled, it uses the shared stack external ID."
+                  >
+                    <Switch
+                      data-testid="per-ds-external-id-toggle"
+                      value={usePerDatasourceExternalId}
+                      onChange={(e) => onPerDatasourceExternalIdToggle(e.currentTarget.checked)}
+                    />
+                  </Field>
+                )}
                 {options.jsonData.authType === AwsAuthType.GrafanaAssumeRole && grafanaExternalIdDisplay && (
                   <Field
                     htmlFor="grafanaExternalId"

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -86,6 +86,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   );
   const isGrafanaAssumeRole = options.jsonData.authType === AwsAuthType.GrafanaAssumeRole;
   const perDatasourceExternalId = options.jsonData.grafanaExternalId;
+  // Only warn when an Assume Role ARN is already set — otherwise there is no trust policy
+  // to update yet (covers Connections create-then-configure, where id is already assigned).
+  const shouldWarnExternalIdChange = Boolean(options.jsonData.assumeRoleArn);
   // props.externalId is often the resolved /external-id value (per-DS when that mode was active).
   // When it matches a stored per-DS ID, derive the real stack prefix for stack-mode display/minting.
   const stackExternalId = useMemo(() => {
@@ -146,7 +149,9 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (!perDsExternalIdFeatureEnabled || !isGrafanaAssumeRole) {
       return;
     }
-    setShowExternalIdChangeWarning(enabled !== initialUsePerDatasourceExternalIdRef.current);
+    setShowExternalIdChangeWarning(
+      shouldWarnExternalIdChange && enabled !== initialUsePerDatasourceExternalIdRef.current
+    );
     if (enabled) {
       pendingPerDsExternalIdRef.current = true;
       const next = applyGrafanaExternalId({
@@ -268,8 +273,10 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                   const mintedExternalId = !hadPerDatasourceExternalId && Boolean(next.jsonData.grafanaExternalId);
                   // Warn when leaving another auth type causes a new per-DS external ID to be set.
                   // Also warn if mint is pending (stack ID / uid not ready yet) — save will still set it.
+                  // Skip until Assume Role ARN is set — no trust policy to update yet.
                   setShowExternalIdChangeWarning(
                     Boolean(
+                      shouldWarnExternalIdChange &&
                       perDsExternalIdFeatureEnabled &&
                       (mintedExternalId || (!hadPerDatasourceExternalId && (!stackExternalId || !options.uid))) &&
                       previousAuthType &&

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -85,16 +85,20 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   const isGrafanaAssumeRole = options.jsonData.authType === AwsAuthType.GrafanaAssumeRole;
   const perDatasourceExternalId = options.jsonData.grafanaExternalId;
   const stackExternalId = props.externalId;
-  // Prefer per-DS ID; fall back to stack-level ID (props.externalId) for legacy datasources only.
+  // Toggle on when bool is true, or legacy configs that only have grafanaExternalId set.
+  const usePerDatasourceExternalId =
+    options.jsonData.usePerDatasourceExternalId === true ||
+    (options.jsonData.usePerDatasourceExternalId === undefined && Boolean(perDatasourceExternalId));
+  // Active ID for STS/display: per-DS when mode on, otherwise stack.
   const grafanaExternalIdDisplay = useMemo(() => {
     if (!isGrafanaAssumeRole) {
       return undefined;
     }
-    if (perDatasourceExternalId) {
+    if (usePerDatasourceExternalId && perDatasourceExternalId) {
       return perDatasourceExternalId;
     }
     return stackExternalId || undefined;
-  }, [isGrafanaAssumeRole, perDatasourceExternalId, stackExternalId]);
+  }, [isGrafanaAssumeRole, usePerDatasourceExternalId, perDatasourceExternalId, stackExternalId]);
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);
 
   const applyGrafanaExternalId = (nextOptions = options) => {
@@ -125,22 +129,16 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     };
   };
 
-  // Toggle on when bool is true, or legacy configs that only have grafanaExternalId set.
-  const usePerDatasourceExternalId =
-    options.jsonData.usePerDatasourceExternalId === true ||
-    (options.jsonData.usePerDatasourceExternalId === undefined && Boolean(perDatasourceExternalId));
-
   const onPerDatasourceExternalIdToggle = (enabled: boolean) => {
     if (!perDsExternalIdFeatureEnabled || !isGrafanaAssumeRole) {
       return;
     }
     if (enabled) {
       pendingPerDsExternalIdRef.current = true;
-      const { grafanaExternalId: _cleared, ...restJsonData } = options.jsonData;
       const next = applyGrafanaExternalId({
         ...options,
         jsonData: {
-          ...restJsonData,
+          ...options.jsonData,
           usePerDatasourceExternalId: true,
         },
       });
@@ -155,7 +153,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       jsonData: {
         ...options.jsonData,
         usePerDatasourceExternalId: false,
-        grafanaExternalId: '',
+        // Keep grafanaExternalId dormant; aws-sdk uses the bool for STS mode.
       },
     });
   };

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -130,7 +130,10 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     }
     if (enabled) {
       pendingPerDsExternalIdRef.current = true;
-      const next = applyGrafanaExternalId(options);
+      // Drop a persisted empty grafanaExternalId key so applyGrafanaExternalId's stack-mode
+      // guard (present-but-empty key) doesn't block minting a fresh per-DS ID.
+      const { grafanaExternalId: _grafanaExternalId, ...restJsonData } = options.jsonData;
+      const next = applyGrafanaExternalId({ ...options, jsonData: restJsonData });
       setShowExternalIdChangeWarning(true);
       onOptionsChange(next);
       return;

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -94,15 +94,11 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   // Toggle reflects explicit bool only; unset (legacy) is stack mode.
   const usePerDatasourceExternalId = options.jsonData.usePerDatasourceExternalId === true;
   // Active ID for STS/display: per-DS when mode on, otherwise stack.
-  const grafanaExternalIdDisplay = useMemo(() => {
-    if (!isGrafanaAssumeRole) {
-      return undefined;
-    }
-    if (usePerDatasourceExternalId && perDatasourceExternalId) {
-      return perDatasourceExternalId;
-    }
-    return stackExternalId || undefined;
-  }, [isGrafanaAssumeRole, usePerDatasourceExternalId, perDatasourceExternalId, stackExternalId]);
+  const grafanaExternalIdDisplay = !isGrafanaAssumeRole
+    ? undefined
+    : usePerDatasourceExternalId && perDatasourceExternalId
+      ? perDatasourceExternalId
+      : stackExternalId || undefined;
   const currentProvider = awsAuthProviderOptions.find((p) => p.value === options.jsonData.authType);
 
   const applyGrafanaExternalId = (nextOptions = options) => {
@@ -114,24 +110,25 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     if (nextOptions.jsonData.usePerDatasourceExternalId === false) {
       return nextOptions;
     }
-    if (nextOptions.jsonData.grafanaExternalId) {
-      return {
-        ...nextOptions,
-        jsonData: {
-          ...nextOptions.jsonData,
-          usePerDatasourceExternalId: true,
-        },
-      };
-    }
     return {
       ...nextOptions,
       jsonData: {
         ...nextOptions.jsonData,
         usePerDatasourceExternalId: true,
-        grafanaExternalId: buildGrafanaExternalId(stackExternalId, nextOptions.uid),
+        grafanaExternalId:
+          nextOptions.jsonData.grafanaExternalId || buildGrafanaExternalId(stackExternalId, nextOptions.uid),
       },
     };
   };
+
+  const withPerDsMode = (base = options) =>
+    applyGrafanaExternalId({
+      ...base,
+      jsonData: {
+        ...base.jsonData,
+        usePerDatasourceExternalId: true,
+      },
+    });
 
   const onPerDatasourceExternalIdToggle = (enabled: boolean) => {
     if (!perDsExternalIdFeatureEnabled || !isGrafanaAssumeRole) {
@@ -142,14 +139,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     );
     if (enabled) {
       pendingPerDsExternalIdRef.current = true;
-      const next = applyGrafanaExternalId({
-        ...options,
-        jsonData: {
-          ...options.jsonData,
-          usePerDatasourceExternalId: true,
-        },
-      });
-      onOptionsChange(next);
+      onOptionsChange(withPerDsMode());
       return;
     }
     pendingPerDsExternalIdRef.current = false;
@@ -161,6 +151,41 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
         // Keep grafanaExternalId dormant; aws-sdk uses the bool for STS mode.
       },
     });
+  };
+
+  const onAuthProviderChange = (option: { value?: AwsAuthType | null }) => {
+    if (option.value !== AwsAuthType.GrafanaAssumeRole) {
+      setShowExternalIdChangeWarning(false);
+      onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
+      return;
+    }
+
+    const previousAuthType = options.jsonData.authType;
+    const hadPerDatasourceExternalId = Boolean(options.jsonData.grafanaExternalId);
+    if (perDsExternalIdFeatureEnabled) {
+      pendingPerDsExternalIdRef.current = true;
+    }
+    const next = applyGrafanaExternalId({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        authType: AwsAuthType.GrafanaAssumeRole,
+        // Keep explicit stack mode; otherwise default to per-DS for this auth switch.
+        usePerDatasourceExternalId: options.jsonData.usePerDatasourceExternalId === false ? false : true,
+      },
+    });
+    const willChangeExternalId =
+      !hadPerDatasourceExternalId && (Boolean(next.jsonData.grafanaExternalId) || !stackExternalId || !options.uid);
+    setShowExternalIdChangeWarning(
+      Boolean(
+        shouldWarnExternalIdChange &&
+        perDsExternalIdFeatureEnabled &&
+        willChangeExternalId &&
+        previousAuthType &&
+        previousAuthType !== AwsAuthType.GrafanaAssumeRole
+      )
+    );
+    onOptionsChange(next);
   };
 
   useEffect(() => {
@@ -181,13 +206,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       // Legacy datasources already have authType set and are skipped by !currentProvider.
       if (defaultAuthType === AwsAuthType.GrafanaAssumeRole && perDsExternalIdFeatureEnabled) {
         pendingPerDsExternalIdRef.current = true;
-        next = applyGrafanaExternalId({
-          ...next,
-          jsonData: {
-            ...next.jsonData,
-            usePerDatasourceExternalId: true,
-          },
-        });
+        next = withPerDsMode(next);
       }
       onOptionsChange(next);
     }
@@ -208,15 +227,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     ) {
       return;
     }
-    onOptionsChange(
-      applyGrafanaExternalId({
-        ...options,
-        jsonData: {
-          ...options.jsonData,
-          usePerDatasourceExternalId: true,
-        },
-      })
-    );
+    onOptionsChange(withPerDsMode());
     // eslint-disable-next-line react-hooks/exhaustive-deps -- retry minting when stack ID / uid become available
   }, [stackExternalId, options.uid, isGrafanaAssumeRole, perDatasourceExternalId, perDsExternalIdFeatureEnabled]);
 
@@ -243,54 +254,10 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
               value={currentProvider}
               options={awsAuthProviderOptions.filter((opt) => awsAllowedAuthProviders.includes(opt.value!))}
               defaultValue={options.jsonData.authType}
-              onChange={(option) => {
-                if (option.value === AwsAuthType.GrafanaAssumeRole) {
-                  const previousAuthType = options.jsonData.authType;
-                  const hadPerDatasourceExternalId = Boolean(options.jsonData.grafanaExternalId);
-                  if (perDsExternalIdFeatureEnabled) {
-                    pendingPerDsExternalIdRef.current = true;
-                  }
-                  const next = applyGrafanaExternalId({
-                    ...options,
-                    jsonData: {
-                      ...options.jsonData,
-                      authType: AwsAuthType.GrafanaAssumeRole,
-                      usePerDatasourceExternalId: options.jsonData.usePerDatasourceExternalId === false ? false : true,
-                    },
-                  });
-                  const mintedExternalId = !hadPerDatasourceExternalId && Boolean(next.jsonData.grafanaExternalId);
-                  // Warn when leaving another auth type causes a new per-DS external ID to be set.
-                  // Also warn if mint is pending (stack ID / uid not ready yet) — save will still set it.
-                  // Skip until Assume Role ARN is set — no trust policy to update yet.
-                  setShowExternalIdChangeWarning(
-                    Boolean(
-                      shouldWarnExternalIdChange &&
-                      perDsExternalIdFeatureEnabled &&
-                      (mintedExternalId || (!hadPerDatasourceExternalId && (!stackExternalId || !options.uid))) &&
-                      previousAuthType &&
-                      previousAuthType !== AwsAuthType.GrafanaAssumeRole
-                    )
-                  );
-                  onOptionsChange(next);
-                  return;
-                }
-                setShowExternalIdChangeWarning(false);
-                onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
-              }}
+              onChange={onAuthProviderChange}
               menuShouldPortal={true}
             />
           </Field>
-          {showExternalIdChangeWarning && (
-            <Alert
-              severity="warning"
-              title="External ID will change on save"
-              data-testid="grafana-external-id-change-warning"
-            >
-              Saving will change the external ID used to assume this role (switching between the data source-specific ID
-              and the shared stack ID). Update your IAM role trust policy to match the new external ID or Assume Role
-              will fail.
-            </Alert>
-          )}
           {options.jsonData.authType === 'credentials' && (
             <Field
               label="Credentials Profile Name"
@@ -451,7 +418,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                 </Field>
                 {perDsExternalIdFeatureEnabled && isGrafanaAssumeRole && (
                   <Field
-                    label="Per-data-source external ID"
+                    label="Per Data Source External ID"
                     description="When enabled, this data source uses a unique external ID. When disabled, it uses the shared stack external ID."
                   >
                     <Switch
@@ -475,6 +442,17 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
                   >
                     <Input id="grafanaExternalId" readOnly value={grafanaExternalIdDisplay} />
                   </Field>
+                )}
+                {showExternalIdChangeWarning && (
+                  <Alert
+                    severity="warning"
+                    title="External ID will change on save"
+                    data-testid="grafana-external-id-change-warning"
+                  >
+                    Saving will change the external ID used to assume this role (switching between the data
+                    source-specific ID and the shared stack ID). Update your IAM role trust policy to match the new
+                    external ID or Assume Role will fail.
+                  </Alert>
                 )}
                 {options.jsonData.authType !== AwsAuthType.GrafanaAssumeRole && (
                   <Field

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -161,9 +161,12 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
       return;
     }
 
-    if (perDsExternalIdFeatureEnabled) {
-      pendingPerDsExternalIdRef.current = true;
+    if (!perDsExternalIdFeatureEnabled) {
+      onUpdateDatasourceJsonDataOptionSelect(props, 'authType')(option);
+      return;
     }
+
+    pendingPerDsExternalIdRef.current = true;
     onOptionsChange(
       applyGrafanaExternalId({
         ...options,

--- a/src/components/utils/grafanaExternalId.test.ts
+++ b/src/components/utils/grafanaExternalId.test.ts
@@ -1,8 +1,4 @@
-import {
-  buildGrafanaExternalId,
-  isValidGrafanaExternalId,
-  stackExternalIdFromGrafanaExternalId,
-} from './grafanaExternalId';
+import { buildGrafanaExternalId, isValidGrafanaExternalId } from './grafanaExternalId';
 
 describe('grafanaExternalId', () => {
   it('builds stack-uid format', () => {
@@ -10,11 +6,5 @@ describe('grafanaExternalId', () => {
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'dsUid1')).toBe(true);
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'other', 'dsUid1')).toBe(false);
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'other')).toBe(false);
-  });
-
-  it('derives stack external ID from per-datasource ID', () => {
-    expect(stackExternalIdFromGrafanaExternalId('stackABC-dsUid1', 'dsUid1')).toBe('stackABC');
-    expect(stackExternalIdFromGrafanaExternalId('stackABC-dsUid1', 'other')).toBeUndefined();
-    expect(stackExternalIdFromGrafanaExternalId(undefined, 'dsUid1')).toBeUndefined();
   });
 });

--- a/src/components/utils/grafanaExternalId.test.ts
+++ b/src/components/utils/grafanaExternalId.test.ts
@@ -1,4 +1,8 @@
-import { buildGrafanaExternalId, isValidGrafanaExternalId } from './grafanaExternalId';
+import {
+  buildGrafanaExternalId,
+  isValidGrafanaExternalId,
+  stackExternalIdFromGrafanaExternalId,
+} from './grafanaExternalId';
 
 describe('grafanaExternalId', () => {
   it('builds stack-uid format', () => {
@@ -6,5 +10,11 @@ describe('grafanaExternalId', () => {
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'dsUid1')).toBe(true);
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'other', 'dsUid1')).toBe(false);
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'other')).toBe(false);
+  });
+
+  it('derives stack external ID from per-datasource ID', () => {
+    expect(stackExternalIdFromGrafanaExternalId('stackABC-dsUid1', 'dsUid1')).toBe('stackABC');
+    expect(stackExternalIdFromGrafanaExternalId('stackABC-dsUid1', 'other')).toBeUndefined();
+    expect(stackExternalIdFromGrafanaExternalId(undefined, 'dsUid1')).toBeUndefined();
   });
 });

--- a/src/components/utils/grafanaExternalId.test.ts
+++ b/src/components/utils/grafanaExternalId.test.ts
@@ -1,10 +1,7 @@
-import { buildGrafanaExternalId, isValidGrafanaExternalId } from './grafanaExternalId';
+import { buildGrafanaExternalId } from './grafanaExternalId';
 
 describe('grafanaExternalId', () => {
   it('builds stack-uid format', () => {
     expect(buildGrafanaExternalId('stackABC', 'dsUid1')).toBe('stackABC-dsUid1');
-    expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'dsUid1')).toBe(true);
-    expect(isValidGrafanaExternalId('stackABC-dsUid1', 'other', 'dsUid1')).toBe(false);
-    expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'other')).toBe(false);
   });
 });

--- a/src/components/utils/grafanaExternalId.test.ts
+++ b/src/components/utils/grafanaExternalId.test.ts
@@ -1,0 +1,16 @@
+import { buildGrafanaExternalId, generateDatasourceUid, isValidGrafanaExternalId } from './grafanaExternalId';
+
+describe('grafanaExternalId', () => {
+  it('builds stack-uid format', () => {
+    expect(buildGrafanaExternalId('stackABC', 'dsUid1')).toBe('stackABC-dsUid1');
+    expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'dsUid1')).toBe(true);
+    expect(isValidGrafanaExternalId('stackABC-dsUid1', 'other', 'dsUid1')).toBe(false);
+    expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'other')).toBe(false);
+  });
+
+  it('generates uid starting with a letter', () => {
+    const uid = generateDatasourceUid();
+    expect(uid[0]).toMatch(/[a-f]/);
+    expect(uid.length).toBeGreaterThan(8);
+  });
+});

--- a/src/components/utils/grafanaExternalId.test.ts
+++ b/src/components/utils/grafanaExternalId.test.ts
@@ -1,4 +1,4 @@
-import { buildGrafanaExternalId, generateDatasourceUid, isValidGrafanaExternalId } from './grafanaExternalId';
+import { buildGrafanaExternalId, isValidGrafanaExternalId } from './grafanaExternalId';
 
 describe('grafanaExternalId', () => {
   it('builds stack-uid format', () => {
@@ -6,11 +6,5 @@ describe('grafanaExternalId', () => {
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'dsUid1')).toBe(true);
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'other', 'dsUid1')).toBe(false);
     expect(isValidGrafanaExternalId('stackABC-dsUid1', 'stackABC', 'other')).toBe(false);
-  });
-
-  it('generates uid starting with a letter', () => {
-    const uid = generateDatasourceUid();
-    expect(uid[0]).toMatch(/[a-f]/);
-    expect(uid.length).toBeGreaterThan(8);
   });
 });

--- a/src/components/utils/grafanaExternalId.ts
+++ b/src/components/utils/grafanaExternalId.ts
@@ -6,11 +6,3 @@
 export function buildGrafanaExternalId(stackExternalId: string, datasourceUid: string): string {
   return `${stackExternalId}-${datasourceUid}`;
 }
-
-/** True if id is bound to this stack + datasource UID. */
-export function isValidGrafanaExternalId(id: string, stackExternalId: string, datasourceUid: string): boolean {
-  if (!id || !stackExternalId || !datasourceUid) {
-    return false;
-  }
-  return id === buildGrafanaExternalId(stackExternalId, datasourceUid);
-}

--- a/src/components/utils/grafanaExternalId.ts
+++ b/src/components/utils/grafanaExternalId.ts
@@ -1,0 +1,28 @@
+/**
+ * Builds a Grafana Assume Role external ID bound to stack + datasource UID.
+ * Format: `{stackExternalId}-{datasourceUid}`
+ * Must match server validation in Grafana's datasource service.
+ */
+export function buildGrafanaExternalId(stackExternalId: string, datasourceUid: string): string {
+  return `${stackExternalId}-${datasourceUid}`;
+}
+
+/** True if id is bound to this stack + datasource UID. */
+export function isValidGrafanaExternalId(id: string, stackExternalId: string, datasourceUid: string): boolean {
+  if (!id || !stackExternalId || !datasourceUid) {
+    return false;
+  }
+  return id === buildGrafanaExternalId(stackExternalId, datasourceUid);
+}
+
+/**
+ * Generates a short datasource UID suitable for pre-save ID construction.
+ * Grafana assigns UIDs on create in the normal UI flow; this covers edge cases.
+ */
+export function generateDatasourceUid(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  // Must start with a letter (k8s name / Grafana short UID convention).
+  return `a${hex}`;
+}

--- a/src/components/utils/grafanaExternalId.ts
+++ b/src/components/utils/grafanaExternalId.ts
@@ -14,23 +14,3 @@ export function isValidGrafanaExternalId(id: string, stackExternalId: string, da
   }
   return id === buildGrafanaExternalId(stackExternalId, datasourceUid);
 }
-
-/**
- * Extracts the stack external ID from a per-datasource ID (`{stack}-{uid}`).
- * Plugins often pass the resolved `/external-id` value as `props.externalId`,
- * which may be the per-DS ID — deriving from grafanaExternalId keeps stack mode display correct.
- */
-export function stackExternalIdFromGrafanaExternalId(
-  grafanaExternalId: string | undefined,
-  datasourceUid: string | undefined
-): string | undefined {
-  if (!grafanaExternalId || !datasourceUid) {
-    return undefined;
-  }
-  const suffix = `-${datasourceUid}`;
-  if (!grafanaExternalId.endsWith(suffix)) {
-    return undefined;
-  }
-  const stack = grafanaExternalId.slice(0, -suffix.length);
-  return stack || undefined;
-}

--- a/src/components/utils/grafanaExternalId.ts
+++ b/src/components/utils/grafanaExternalId.ts
@@ -14,15 +14,3 @@ export function isValidGrafanaExternalId(id: string, stackExternalId: string, da
   }
   return id === buildGrafanaExternalId(stackExternalId, datasourceUid);
 }
-
-/**
- * Generates a short datasource UID suitable for pre-save ID construction.
- * Grafana assigns UIDs on create in the normal UI flow; this covers edge cases.
- */
-export function generateDatasourceUid(): string {
-  const bytes = new Uint8Array(8);
-  crypto.getRandomValues(bytes);
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
-  // Must start with a letter (k8s name / Grafana short UID convention).
-  return `a${hex}`;
-}

--- a/src/components/utils/grafanaExternalId.ts
+++ b/src/components/utils/grafanaExternalId.ts
@@ -14,3 +14,23 @@ export function isValidGrafanaExternalId(id: string, stackExternalId: string, da
   }
   return id === buildGrafanaExternalId(stackExternalId, datasourceUid);
 }
+
+/**
+ * Extracts the stack external ID from a per-datasource ID (`{stack}-{uid}`).
+ * Plugins often pass the resolved `/external-id` value as `props.externalId`,
+ * which may be the per-DS ID — deriving from grafanaExternalId keeps stack mode display correct.
+ */
+export function stackExternalIdFromGrafanaExternalId(
+  grafanaExternalId: string | undefined,
+  datasourceUid: string | undefined
+): string | undefined {
+  if (!grafanaExternalId || !datasourceUid) {
+    return undefined;
+  }
+  const suffix = `-${datasourceUid}`;
+  if (!grafanaExternalId.endsWith(suffix)) {
+    return undefined;
+  }
+  const stack = grafanaExternalId.slice(0, -suffix.length);
+  return stack || undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,13 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
   authType?: AwsAuthType;
   assumeRoleArn?: string;
   externalId?: string;
+  /**
+   * Per-datasource external ID for Grafana Assume Role auth.
+   * Format: `{stackExternalId}-{dsUid}`. Set once (UI or server),
+   * then immutable. When unset, Grafana falls back to the stack-level
+   * external ID (legacy shared isolation).
+   */
+  grafanaExternalId?: string;
   profile?: string; // Credentials profile name, as specified in ~/.aws/credentials
   defaultRegion?: string; // region if it is not defined by your credentials file
   endpoint?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,9 +25,9 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
   usePerDatasourceExternalId?: boolean;
   /**
    * Per-datasource external ID for Grafana Assume Role auth.
-   * Format: `{stackExternalId}-{dsUid}`. Cleared when
-   * `usePerDatasourceExternalId` is false. When unset with stack mode,
-   * Grafana falls back to the stack-level external ID.
+   * Format: `{stackExternalId}-{dsUid}`. Kept when
+   * `usePerDatasourceExternalId` is false (dormant); aws-sdk uses the bool
+   * to choose this vs the stack-level external ID at STS time.
    */
   grafanaExternalId?: string;
   profile?: string; // Credentials profile name, as specified in ~/.aws/credentials

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,17 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
   assumeRoleArn?: string;
   externalId?: string;
   /**
+   * When true, Grafana Assume Role uses a per-datasource external ID
+   * (`grafanaExternalId`). When false, uses the shared stack external ID.
+   * Omit to leave mode unchanged on update (e.g. Terraform). New UI configs
+   * default this to true when the feature toggle is on.
+   */
+  usePerDatasourceExternalId?: boolean;
+  /**
    * Per-datasource external ID for Grafana Assume Role auth.
-   * Format: `{stackExternalId}-{dsUid}`. Set once (UI or server),
-   * then immutable. When unset, Grafana falls back to the stack-level
-   * external ID (legacy shared isolation).
+   * Format: `{stackExternalId}-{dsUid}`. Cleared when
+   * `usePerDatasourceExternalId` is false. When unset with stack mode,
+   * Grafana falls back to the stack-level external ID.
    */
   grafanaExternalId?: string;
   profile?: string; // Credentials profile name, as specified in ~/.aws/credentials

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,9 +18,9 @@ export interface AwsAuthDataSourceJsonData extends DataSourceJsonData {
   externalId?: string;
   /**
    * When true, Grafana Assume Role uses a per-datasource external ID
-   * (`grafanaExternalId`). When false, uses the shared stack external ID.
-   * Omit to leave mode unchanged on update (e.g. Terraform). New UI configs
-   * default this to true when the feature toggle is on.
+   * (`grafanaExternalId`). When false or omitted, uses the shared stack
+   * external ID (legacy). New UI configs set this to true when the feature
+   * toggle is on. Omit on update to leave the stored value unchanged (Terraform).
    */
   usePerDatasourceExternalId?: boolean;
   /**


### PR DESCRIPTION
## Summary
Related: grafana/oss-plugin-partnerships#1473

This is the aws-sdk-react part of the work, if you want to actually try it working you need the other branches from the linked issue.

- Add FT-gated toggle for per-datasource vs stack Grafana Assume Role external ID
- Persist choice in `jsonData.usePerDatasourceExternalId`; keep `jsonData.grafanaExternalId` when toggling off (dormant)
- When FT is on:
  - toggle on → mint/reuse per-DS ID when `options.uid` is set
  - toggle off → set bool false; keep stored ID; show **stack** external ID from `props.externalId`
  - warning clears if the toggle is returned to its original value
  - warning only when `assumeRoleArn` is set (no trust policy to update during setup)
- When FT is off: still display stack (or existing active per-DS only when mode bool is true); do not mint or show the toggle
- No client-side UID inventing; server mints on save when needed



## Screenshots
<img width="483" height="463" alt="Screenshot 2026-07-16 at 3 43 01 PM" src="https://github.com/user-attachments/assets/09b4fe41-ef57-4d15-966c-70511dc5145f" />
<img width="522" height="603" alt="Screenshot 2026-07-16 at 3 43 50 PM" src="https://github.com/user-attachments/assets/ceee5c9f-dc53-497f-bafc-200ff4230bd6" />


## Test plan
- [x] `yarn test --watchAll=false src/components/ConnectionConfig.test.tsx src/components/utils/grafanaExternalId.test.ts`
- [ ] `yarn build`
- [ ] FT on: toggle appears; off keeps ID and shows stack; on reuses dormant ID
- [ ] FT on: flip toggle away and back → warning gone
- [ ] FT on + no ARN: toggle/auth switch does not warn
- [ ] FT on + ARN set: mode change warns
- [ ] FT on + empty uid: no UI mint; save relies on server
- [ ] FT off: no toggle/mint/warn

## Merge order
- grafana FT #128424: **merged**
- grafana-aws-sdk #470 (v1.5.1): **released**
- Review alongside grafana core #128425 (mint/preserve)
- Downstream CloudWatch: bump this package after release; `/external-id` must return stack ID only (not resolved per-DS)