### PR TITLE
ci: use shared reusable stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,29 +1,13 @@
-name: 'Close stale issues'
+name: 'Close stale issues and PRs'
 on:
   schedule:
-    # run at 1:30 every day
     - cron: '30 1 * * *'
+
+permissions: {}
 
 jobs:
   stale:
     permissions:
       issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # start from the oldest issues when performing stale operations
-          ascending: true
-          days-before-issue-stale: 365
-          days-before-issue-close: 30
-          stale-issue-label: stale
-          exempt-issue-labels: no stalebot,type/epic
-          stale-issue-message: >
-            This issue has been automatically marked as stale because it has not had
-            activity in the last year. It will be closed in 30 days if no further activity occurs. Please
-            feel free to leave a comment if you believe the issue is still relevant.
-            Thank you for your contributions!
-          close-issue-message: >
-            This issue has been automatically closed because it has not had any further
-            activity in the last 30 days. Thank you for your contributions!
+      pull-requests: write
+    uses: grafana/data-sources-ci-workflows/.github/workflows/reusable-stale.yml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Migrates the stale workflow to the shared reusable workflow from `grafana/data-sources-ci-workflows`. This also enables stale handling for pull requests (previously issues-only).