### PR TITLE
feat: SigV4 per-datasource Grafana Assume Role external ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.12.1
+
+- Support per-datasource Grafana Assume Role external IDs for SigV4 datasources in [#501](https://github.com/grafana/grafana-aws-sdk-react/pull/501)
+
 ## v0.12.0
 
 - Add UI toggle for per-datasource grafanaExternalId (Grafana Assume Role) in [#496](https://github.com/grafana/grafana-aws-sdk-react/pull/496)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/aws-sdk",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Common AWS features for grafana",
   "type": "module",
   "main": "dist/cjs/index.cjs",

--- a/src/components/ConnectionConfig.test.tsx
+++ b/src/components/ConnectionConfig.test.tsx
@@ -86,6 +86,7 @@ describe('ConnectionConfig', () => {
     config.awsAllowedAuthProviders = [AwsAuthType.EC2IAMRole, AwsAuthType.Keys, AwsAuthType.Credentials];
     config.featureToggles.awsDatasourcesTempCredentials = false;
     config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
+    config.namespace = '';
     //@ts-ignore
     config.awsAssumeRoleEnabled = undefined;
   });
@@ -236,6 +237,28 @@ describe('ConnectionConfig', () => {
     await waitFor(() => expect(onOptionsChange).toHaveBeenCalled());
     const update = onOptionsChange.mock.calls.find((call) => call[0]?.jsonData?.grafanaExternalId)?.[0];
     expect(update.jsonData.grafanaExternalId).toBe('stackABC-dsUid1');
+  });
+
+  it('should derive stack external ID from config.namespace when props.externalId is missing (Cloud / SigV4 path)', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    config.namespace = 'stacks-12345';
+    const onOptionsChange = jest.fn();
+    const props = getProps({
+      onOptionsChange,
+      // No externalId prop — OpenSearch / SigV4 rely on namespace like Grafana Cloud.
+      options: {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'grafana-opensearch-datasource',
+        jsonData: { authType: undefined },
+      },
+    });
+    render(<ConnectionConfig {...props} />);
+    await waitFor(() => expect(onOptionsChange).toHaveBeenCalled());
+    const update = onOptionsChange.mock.calls.find((call) => call[0]?.jsonData?.grafanaExternalId)?.[0];
+    expect(update.jsonData.grafanaExternalId).toBe('12345-dsUid1');
   });
 
   it('should not mint a per-datasource external ID when the feature toggle is off', async () => {
@@ -677,6 +700,55 @@ describe('ConnectionConfig', () => {
 
       await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
       expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
+    });
+
+    it('clears the warning and rebases after save (options.version bump)', async () => {
+      config.featureToggles.awsDatasourcesTempCredentials = true;
+      config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+      config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+      const onOptionsChange = jest.fn();
+      const baseOptions = {
+        id: 21,
+        uid: 'dsUid1',
+        type: 'cloudwatch',
+        version: 1,
+        jsonData: {
+          authType: AwsAuthType.GrafanaAssumeRole,
+          assumeRoleArn: 'arn:aws:iam::123:role/test',
+          usePerDatasourceExternalId: true,
+          grafanaExternalId: 'stackABC-dsUid1',
+        },
+      };
+      const props = getProps({
+        onOptionsChange,
+        externalId: 'stackABC',
+        options: baseOptions,
+      });
+      const { rerender } = render(<ConnectionConfig {...props} />);
+
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
+
+      const afterDisable = onOptionsChange.mock.calls.at(-1)?.[0];
+      // Simulate successful save: persisted toggle + bumped version.
+      rerender(
+        <ConnectionConfig
+          {...props}
+          options={{
+            ...afterDisable,
+            version: 2,
+            jsonData: {
+              ...afterDisable.jsonData,
+              usePerDatasourceExternalId: false,
+            },
+          }}
+        />
+      );
+      expect(screen.queryByTestId('grafana-external-id-change-warning')).not.toBeInTheDocument();
+
+      // Changing again after save should warn relative to the newly saved baseline (false).
+      await userEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+      expect(screen.getByTestId('grafana-external-id-change-warning')).toBeInTheDocument();
     });
   });
 

--- a/src/components/ConnectionConfig.tsx
+++ b/src/components/ConnectionConfig.tsx
@@ -56,6 +56,7 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   const pendingPerDsExternalIdRef = useRef(false);
   // Persisted/opened mode — warn only while the toggle differs from this value.
   const initialUsePerDatasourceExternalIdRef = useRef(props.options.jsonData.usePerDatasourceExternalId === true);
+  const savedOptionsVersionRef = useRef(props.options.version);
   const {
     loadRegions,
     onOptionsChange,
@@ -66,6 +67,16 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
     showHttpProxySettings = false,
   } = props;
   useConfigSaveReporter(options.type, options.jsonData.authType);
+
+  // After save Grafana bumps options.version — treat current toggle as the new baseline and clear the warning.
+  useEffect(() => {
+    if (savedOptionsVersionRef.current === options.version) {
+      return;
+    }
+    savedOptionsVersionRef.current = options.version;
+    initialUsePerDatasourceExternalIdRef.current = options.jsonData.usePerDatasourceExternalId === true;
+    setShowExternalIdChangeWarning(false);
+  }, [options.version, options.jsonData.usePerDatasourceExternalId]);
   let profile = options.jsonData.profile;
   if (profile === undefined) {
     profile = options.database;
@@ -89,8 +100,12 @@ export const ConnectionConfig: FC<ConnectionConfigProps> = (props: ConnectionCon
   // Only warn when an Assume Role ARN is already set — otherwise there is no trust policy
   // to update yet (covers Connections create-then-configure, where id is already assigned).
   const shouldWarnExternalIdChange = Boolean(options.jsonData.assumeRoleArn);
-  // Stack ID from the plugin (e.g. CloudWatch /external-id → AWS_AUTH_EXTERNAL_ID).
-  const stackExternalId = props.externalId;
+  // Stack ID: plugin fetch (CloudWatch /external-id) wins; else Cloud-style namespace
+  // (`stacks-<id>` from [environment] stack_id) — same path OpenSearch uses on Grafana Cloud.
+  const stackExternalIdFromNamespace = config.namespace?.startsWith('stacks-')
+    ? config.namespace.substring(config.namespace.indexOf('-') + 1)
+    : undefined;
+  const stackExternalId = props.externalId || stackExternalIdFromNamespace;
   // Toggle reflects explicit bool only; unset (legacy) is stack mode.
   const usePerDatasourceExternalId = options.jsonData.usePerDatasourceExternalId === true;
   // Active ID for STS/display: per-DS when mode on, otherwise stack.

--- a/src/components/SIGV4ConnectionConfig.test.tsx
+++ b/src/components/SIGV4ConnectionConfig.test.tsx
@@ -1,6 +1,7 @@
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import selectEvent from 'react-select-event';
 import { AwsAuthType } from '../types';
 import { SIGV4ConnectionConfig } from './SIGV4ConnectionConfig';
 import { config } from '@grafana/runtime';
@@ -12,7 +13,9 @@ jest.mock('@grafana/runtime', () => ({
     awsAssumeRoleEnabled: true,
     featureToggles: {
       awsDatasourcesTempCredentials: false,
+      awsAssumeRolePerDatasourceExternalId: false,
     },
+    namespace: '',
   },
   usePluginInteractionReporter: () => jest.fn(),
   getAppEvents: () => ({
@@ -20,21 +23,40 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+interface SetupOptions {
+  optionsOverrides?: Partial<DataSourceSettings<any, any>> & { jsonData?: Record<string, any> };
+  /** Stack ID via Cloud-style config.namespace (`stacks-<id>`). */
+  stackIdViaNamespace?: string;
+  onOptionsChange?: (options: DataSourceSettings<any, any>) => void;
+}
+
 describe('SIGV4ConnectionConfig', () => {
   beforeEach(() => {
     config.awsAllowedAuthProviders = [AwsAuthType.Credentials, AwsAuthType.Keys];
     config.awsAssumeRoleEnabled = true;
     config.featureToggles.awsDatasourcesTempCredentials = false;
+    // @ts-ignore not yet in published @grafana/data FeatureToggles
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = false;
+    config.namespace = '';
   });
-  const setup = (onOptionsChange?: () => {}) => {
+
+  const setup = (setupOptions: SetupOptions = {}) => {
+    const { optionsOverrides = {}, stackIdViaNamespace, onOptionsChange = jest.fn() } = setupOptions;
+    const { jsonData: jsonDataOverrides, ...restOverrides } = optionsOverrides;
+
+    // ConnectionConfig derives stack external ID from config.namespace (Cloud / SigV4 path).
+    if (stackIdViaNamespace !== undefined) {
+      config.namespace = `stacks-${stackIdViaNamespace}`;
+    }
+
     const props: DataSourcePluginOptionsEditorProps<any, any> = {
       options: {
         typeName: '',
         id: 449,
         uid: 'oIoBsD_Mz',
         orgId: 1,
-        name: 'Elasticsearch',
-        type: 'elasticsearch',
+        name: 'OpenSearch',
+        type: 'grafana-opensearch-datasource',
         typeLogoUrl: '',
         access: 'proxy',
         url: 'http://test.ts',
@@ -57,15 +79,19 @@ describe('SIGV4ConnectionConfig', () => {
           sigV4Profile: 'profile',
           sigV4Region: 'us-east-2',
           timeField: '@timestamp',
+          ...jsonDataOverrides,
         },
         secureJsonFields: { sigV4AccessKey: true, sigV4SecretKey: true },
         version: 6,
         readOnly: false,
+        ...restOverrides,
       },
-      onOptionsChange: onOptionsChange ?? jest.fn(),
+      onOptionsChange,
     };
 
     render(<SIGV4ConnectionConfig {...props} />);
+
+    return { onOptionsChange };
   };
 
   it('should map incoming props correctly', () => {
@@ -77,28 +103,151 @@ describe('SIGV4ConnectionConfig', () => {
 
   it('should map changed fields correctly', async () => {
     const onOptionsChange = jest.fn();
-    setup(onOptionsChange);
+    setup({ onOptionsChange });
 
     const labelElement = screen.getByLabelText(/Assume Role ARN/);
     expect(labelElement).toBeInTheDocument();
     fireEvent.change(labelElement, { target: { value: 'changed-arn' } });
 
+    expect(onOptionsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          sigV4AssumeRoleArn: 'changed-arn',
+          // Non-auth OpenSearch fields preserved; unprefixed auth aliases never written.
+          esVersion: '7.10.0',
+          timeField: '@timestamp',
+        }),
+      })
+    );
+    const afterArnChange = onOptionsChange.mock.calls.at(-1)[0].jsonData;
+    expect(afterArnChange.assumeRoleArn).toBeUndefined();
+    expect(afterArnChange.authType).toBeUndefined();
+    expect(afterArnChange.grafanaExternalId).toBeUndefined();
+    expect(afterArnChange.usePerDatasourceExternalId).toBeUndefined();
+
     const externalIdElement = screen.getByLabelText(/External ID/);
     expect(externalIdElement).toBeInTheDocument();
     fireEvent.change(externalIdElement, { target: { value: 'changed-test-id' } });
 
+    expect(onOptionsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        jsonData: expect.objectContaining({
+          sigV4ExternalId: 'changed-test-id',
+        }),
+      })
+    );
+
     const authTypeElement = screen.getByLabelText('Authentication Provider');
     expect(authTypeElement).toBeInTheDocument();
-    fireEvent.change(authTypeElement, { target: { value: 'keys' } });
+    await selectEvent.select(authTypeElement, 'Access & secret key', { container: document.body });
 
-    expect.objectContaining({
-      options: expect.objectContaining({
+    expect(onOptionsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         jsonData: expect.objectContaining({
-          sigV4AssumeRoleArn: 'changed-arn',
-          sigV4ExternalId: 'changed-test-id',
           sigV4AuthType: 'keys',
         }),
-      }),
+      })
+    );
+    const afterAuthType = onOptionsChange.mock.calls.at(-1)[0].jsonData;
+    expect(afterAuthType.authType).toBeUndefined();
+  });
+
+  it('should map sigV4 per-datasource external ID fields into ConnectionConfig', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    // @ts-ignore not yet in published @grafana/data FeatureToggles
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+
+    setup({
+      optionsOverrides: {
+        type: 'grafana-opensearch-datasource',
+        uid: 'dsUid1',
+        jsonData: {
+          sigV4Auth: true,
+          sigV4AuthType: AwsAuthType.GrafanaAssumeRole,
+          sigV4AssumeRoleArn: 'arn:aws:iam::123:role/test',
+          sigV4GrafanaExternalId: 'stackABC-dsUid1',
+          sigV4UsePerDatasourceExternalId: true,
+          sigV4Region: 'us-east-2',
+        },
+      },
+      stackIdViaNamespace: 'stackABC',
     });
+
+    expect(screen.getByTestId('per-ds-external-id-toggle')).toBeChecked();
+    expect(screen.getByDisplayValue('stackABC-dsUid1')).toBeInTheDocument();
+  });
+
+  it('should persist minted per-datasource external ID under sigV4-prefixed keys only', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    // @ts-ignore not yet in published @grafana/data FeatureToggles
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    config.namespace = 'stacks-stackABC';
+
+    const onOptionsChange = jest.fn();
+    setup({
+      onOptionsChange,
+      optionsOverrides: {
+        type: 'grafana-opensearch-datasource',
+        uid: 'dsUid1',
+        jsonData: {
+          sigV4Auth: true,
+          // no sigV4AuthType yet — ConnectionConfig defaults to GAR when allowed
+          sigV4AuthType: undefined,
+          sigV4AssumeRoleArn: undefined,
+          sigV4ExternalId: undefined,
+        },
+      },
+    });
+
+    await waitFor(() => expect(onOptionsChange).toHaveBeenCalled());
+    const update = onOptionsChange.mock.calls.find((call) => call[0]?.jsonData?.sigV4GrafanaExternalId)?.[0];
+
+    expect(update.jsonData.sigV4GrafanaExternalId).toBe('stackABC-dsUid1');
+    expect(update.jsonData.sigV4UsePerDatasourceExternalId).toBe(true);
+    expect(update.jsonData.sigV4AuthType).toBe(AwsAuthType.GrafanaAssumeRole);
+    expect(update.jsonData.grafanaExternalId).toBeUndefined();
+    expect(update.jsonData.usePerDatasourceExternalId).toBeUndefined();
+  });
+
+  it('should write sigV4UsePerDatasourceExternalId false when per-DS toggle is disabled', async () => {
+    config.featureToggles.awsDatasourcesTempCredentials = true;
+    // @ts-ignore not yet in published @grafana/data FeatureToggles
+    config.featureToggles.awsAssumeRolePerDatasourceExternalId = true;
+    config.awsAllowedAuthProviders = [AwsAuthType.GrafanaAssumeRole, AwsAuthType.Credentials];
+    config.namespace = 'stacks-stackABC';
+
+    const onOptionsChange = jest.fn();
+    setup({
+      onOptionsChange,
+      optionsOverrides: {
+        type: 'grafana-opensearch-datasource',
+        uid: 'dsUid1',
+        jsonData: {
+          sigV4Auth: true,
+          sigV4AuthType: AwsAuthType.GrafanaAssumeRole,
+          sigV4AssumeRoleArn: 'arn:aws:iam::123:role/test',
+          sigV4GrafanaExternalId: 'stackABC-dsUid1',
+          sigV4UsePerDatasourceExternalId: true,
+        },
+      },
+    });
+
+    fireEvent.click(screen.getByTestId('per-ds-external-id-toggle'));
+
+    await waitFor(() =>
+      expect(onOptionsChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            sigV4UsePerDatasourceExternalId: false,
+            sigV4GrafanaExternalId: 'stackABC-dsUid1',
+          }),
+        })
+      )
+    );
+    const last = onOptionsChange.mock.calls.at(-1)[0];
+    expect(last.jsonData.usePerDatasourceExternalId).toBeUndefined();
+    expect(last.jsonData.grafanaExternalId).toBeUndefined();
   });
 });

--- a/src/components/SIGV4ConnectionConfig.tsx
+++ b/src/components/SIGV4ConnectionConfig.tsx
@@ -11,21 +11,21 @@ export interface SIGV4ConnectionConfigProps extends DataSourcePluginOptionsEdito
 export const SIGV4ConnectionConfig: React.FC<SIGV4ConnectionConfigProps> = (props: SIGV4ConnectionConfigProps) => {
   const { onOptionsChange, options } = props;
 
+  // Map HttpSettings props to ConnectionConfigProps
   const connectionConfigProps: ConnectionConfigProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> = {
     onOptionsChange: (awsDataSourceSettings) => {
-      const awsJson = awsDataSourceSettings.jsonData;
       const dataSourceSettings: DataSourceSettings<any, any> = {
         ...options,
         jsonData: {
           ...options.jsonData,
-          sigV4AuthType: awsJson.authType,
-          sigV4Profile: awsJson.profile,
-          sigV4AssumeRoleArn: awsJson.assumeRoleArn,
-          sigV4ExternalId: awsJson.externalId,
-          sigV4Region: awsJson.defaultRegion,
-          sigV4Endpoint: awsJson.endpoint,
-          sigV4GrafanaExternalId: awsJson.grafanaExternalId,
-          sigV4UsePerDatasourceExternalId: awsJson.usePerDatasourceExternalId,
+          sigV4AuthType: awsDataSourceSettings.jsonData.authType,
+          sigV4Profile: awsDataSourceSettings.jsonData.profile,
+          sigV4AssumeRoleArn: awsDataSourceSettings.jsonData.assumeRoleArn,
+          sigV4ExternalId: awsDataSourceSettings.jsonData.externalId,
+          sigV4Region: awsDataSourceSettings.jsonData.defaultRegion,
+          sigV4Endpoint: awsDataSourceSettings.jsonData.endpoint,
+          sigV4GrafanaExternalId: awsDataSourceSettings.jsonData.grafanaExternalId,
+          sigV4UsePerDatasourceExternalId: awsDataSourceSettings.jsonData.usePerDatasourceExternalId,
         },
         secureJsonFields: {
           sigV4AccessKey: awsDataSourceSettings.secureJsonFields?.accessKey,

--- a/src/components/SIGV4ConnectionConfig.tsx
+++ b/src/components/SIGV4ConnectionConfig.tsx
@@ -11,19 +11,21 @@ export interface SIGV4ConnectionConfigProps extends DataSourcePluginOptionsEdito
 export const SIGV4ConnectionConfig: React.FC<SIGV4ConnectionConfigProps> = (props: SIGV4ConnectionConfigProps) => {
   const { onOptionsChange, options } = props;
 
-  // Map HttpSettings props to ConnectionConfigProps
   const connectionConfigProps: ConnectionConfigProps<AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData> = {
     onOptionsChange: (awsDataSourceSettings) => {
+      const awsJson = awsDataSourceSettings.jsonData;
       const dataSourceSettings: DataSourceSettings<any, any> = {
         ...options,
         jsonData: {
           ...options.jsonData,
-          sigV4AuthType: awsDataSourceSettings.jsonData.authType,
-          sigV4Profile: awsDataSourceSettings.jsonData.profile,
-          sigV4AssumeRoleArn: awsDataSourceSettings.jsonData.assumeRoleArn,
-          sigV4ExternalId: awsDataSourceSettings.jsonData.externalId,
-          sigV4Region: awsDataSourceSettings.jsonData.defaultRegion,
-          sigV4Endpoint: awsDataSourceSettings.jsonData.endpoint,
+          sigV4AuthType: awsJson.authType,
+          sigV4Profile: awsJson.profile,
+          sigV4AssumeRoleArn: awsJson.assumeRoleArn,
+          sigV4ExternalId: awsJson.externalId,
+          sigV4Region: awsJson.defaultRegion,
+          sigV4Endpoint: awsJson.endpoint,
+          sigV4GrafanaExternalId: awsJson.grafanaExternalId,
+          sigV4UsePerDatasourceExternalId: awsJson.usePerDatasourceExternalId,
         },
         secureJsonFields: {
           sigV4AccessKey: awsDataSourceSettings.secureJsonFields?.accessKey,
@@ -39,13 +41,14 @@ export const SIGV4ConnectionConfig: React.FC<SIGV4ConnectionConfigProps> = (prop
     options: {
       ...options,
       jsonData: {
-        ...options.jsonData,
         authType: options.jsonData.sigV4AuthType,
         profile: options.jsonData.sigV4Profile,
         assumeRoleArn: options.jsonData.sigV4AssumeRoleArn,
         externalId: options.jsonData.sigV4ExternalId,
         defaultRegion: options.jsonData.sigV4Region,
         endpoint: options.jsonData.sigV4Endpoint,
+        grafanaExternalId: options.jsonData.sigV4GrafanaExternalId,
+        usePerDatasourceExternalId: options.jsonData.sigV4UsePerDatasourceExternalId,
       },
       secureJsonFields: {
         accessKey: options.secureJsonFields?.sigV4AccessKey,


### PR DESCRIPTION
## Summary
- Map SigV4 jsonData through prefixed keys (`sigV4GrafanaExternalId`, `sigV4UsePerDatasourceExternalId`) in `SIGV4ConnectionConfig`
- Derive stack external ID from `config.namespace` (`stacks-<id>`) when plugins do not pass `externalId` (Cloud / SigV4 path)
- Clear the per-datasource external ID change warning after save (`options.version` bump)

Part of supporting per-datasource Grafana Assume Role external IDs for SigV4 datasources that already support GAR (e.g. OpenSearch).

## Related PRs
1. **This PR** — UI / `@grafana/aws-sdk` (release first)
2. [grafana#129144](https://github.com/grafana/grafana/pull/129144) — `awsexternalid` mint/scrub for SigV4 keys
3. [grafana-enterprise#12799](https://github.com/grafana/grafana-enterprise/pull/12799) — dsauth STS reads prefixed keys (stacked on [#12656](https://github.com/grafana/grafana-enterprise/pull/12656))

## Test plan
- [ ] With FT `awsAssumeRolePerDatasourceExternalId` + OpenSearch SigV4 GAR: toggle per-DS mode, save, confirm prefixed jsonData keys persist
- [ ] With `config.namespace = stacks-<id>` and no `externalId` prop: stack ID displays / mints correctly
- [ ] After save, external-ID change warning clears; flipping the toggle again shows it relative to the new baseline
- [ ] Native AWS `ConnectionConfig` path still uses unprefixed `grafanaExternalId` / `usePerDatasourceExternalId`